### PR TITLE
Change matchMetadata to matchMeta DM-3453

### DIFF
--- a/python/lsst/meas/astrom/anetBasicAstrometry.py
+++ b/python/lsst/meas/astrom/anetBasicAstrometry.py
@@ -36,7 +36,7 @@ class InitialAstrometry(object):
     sipWcs (Wcs)
     sipMatches (MatchList)
     refCat (lsst::afw::table::SimpleCatalog)
-    matchMetadata (PropertyList)
+    matchMeta (PropertyList)
     """
     def __init__(self):
         self.tanWcs = None
@@ -44,7 +44,7 @@ class InitialAstrometry(object):
         self.sipWcs = None
         self.sipMatches = None
         self.refCat = None
-        self.matchMetadata = dafBase.PropertyList()
+        self.matchMeta = dafBase.PropertyList()
         self.solveQa = None
 
     def getMatches(self):
@@ -76,7 +76,7 @@ class InitialAstrometry(object):
     def getTanMatches(self):
         return self.tanMatches
     def getMatchMetadata(self):
-        return self.matchMetadata
+        return self.matchMeta
     def getSolveQaMetadata(self):
         return self.solveQa
 
@@ -348,7 +348,7 @@ class ANetBasicAstrometryTask(pipeBase.Task):
         # Here, we make them consistent with the WCS we are returning.
         for src in sourceCat:
             src.updateCoord(wcs)
-        astrom.matchMetadata = _createMetadata(bbox, wcs, filterName)
+        astrom.matchMeta = _createMetadata(bbox, wcs, filterName)
         return astrom
 
     def determineWcs(self,

--- a/tests/SourceMatchJoin.py
+++ b/tests/SourceMatchJoin.py
@@ -49,7 +49,7 @@ class matchlistTestCase(unittest.TestCase):
         res = self.getAstrometrySolution()
 
         matches = res.matches
-        matchmeta = res.matchMetadata
+        matchmeta = res.matchMeta
 
         normalized = afwTable.packMatches(matches)
         normalized.table.setMetadata(matchmeta)
@@ -71,7 +71,7 @@ class matchlistTestCase(unittest.TestCase):
         res = self.getAstrometrySolution()
 
         matches = res.matches
-        matchmeta = res.matchMetadata
+        matchmeta = res.matchMeta
 
         normalized = afwTable.packMatches(matches)
         normalized.table.setMetadata(matchmeta)


### PR DESCRIPTION
Standardize astrometry tasks to return catalog metadata as matchMeta,
not matchMetadata.