### PR TITLE
matchOptimisticB: correct for distortion DM-3492

### DIFF
--- a/include/lsst/meas/astrom/matchOptimisticB.h
+++ b/include/lsst/meas/astrom/matchOptimisticB.h
@@ -52,9 +52,14 @@ namespace astrom {
 
     typedef std::vector<RecordProxy> ProxyVector;
 
-    ProxyVector makeProxies(lsst::afw::table::SourceCatalog const & sourceCat);
+    ProxyVector makeProxies(lsst::afw::table::SourceCatalog const & sourceCat,
+                            afw::image::Wcs const& distortedWcs,
+                            afw::image::Wcs const& tanWcs
+        );
 
-    ProxyVector makeProxies(lsst::afw::table::SimpleCatalog const & posRefCat);
+    ProxyVector makeProxies(lsst::afw::table::SimpleCatalog const & posRefCat,
+                            afw::image::Wcs const& tanWcs
+        );
 
     struct ProxyPair {
         RecordProxy first;
@@ -111,13 +116,13 @@ namespace astrom {
     Optimistic Pattern Matching is described in V. Tabur 2007, PASA, 24, 189-198
     "Fast Algorithms for Matching CCD Images to a Stellar Catalogue"
 
-    @param[in] posRefCat  catalog of position reference stars
-        fields that are used:
-        coord
-        centroid
-        hasCentroid
-        control.refFluxField  flux for desired filter
-    @param[in] sourceCat  catalog of detected sources
+    @param[in] posRefCat  catalog of position reference stars; fields read:
+        - "coord"
+        - control.refFluxField
+    @param[in] sourceCat  catalog of detected sources; fields read:
+        - "Centroid_x"
+        - "Centroid_y"
+        - control.refFluxField
     @param[in] wcs  estimated WCS
     @param[in] control  control object
     @param[in] posRefBegInd  index of first start to use in posRefCat
@@ -128,6 +133,7 @@ namespace astrom {
         lsst::afw::table::SimpleCatalog const &posRefCat,
         lsst::afw::table::SourceCatalog const &sourceCat,
         MatchOptimisticBControl const &control,
+        afw::image::Wcs const& wcs,
         int posRefBegInd=0,
         bool verbose = false
     );

--- a/python/lsst/meas/astrom/fitTanSipWcs.py
+++ b/python/lsst/meas/astrom/fitTanSipWcs.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import numpy
 import lsst.afw.image as afwImage
 import lsst.afw.coord as afwCoord
 import lsst.afw.geom as afwGeom
@@ -24,6 +25,18 @@ class FitTanSipWcsConfig(pexConfig.Config):
         dtype = int,
         default = 3,
         min = 1,
+    )
+    numRejIter = pexConfig.RangeField(
+        doc = "number of rejection iterations",
+        dtype = int,
+        default = 1,
+        min = 0,
+    )
+    rejSigma = pexConfig.RangeField(
+        doc = "Number of standard deviations for clipping level",
+        dtype = float,
+        default = 3.0,
+        min = 0.0,
     )
     maxScatterArcsec = pexConfig.RangeField(
         doc = "maximum median scatter of a WCS fit beyond which the fit fails (arcsec); " +
@@ -117,10 +130,27 @@ class FitTanSipWcsTask(pipeBase.Task):
         """
         if bbox is None:
             bbox = afwGeom.Box2I()
+
+        import lsstDebug
+        debug = lsstDebug.Info(__name__)
+
         wcs = self.initialWcs(matches, initWcs)
-        for i in range(self.config.numIter):
-            sipObject = makeCreateWcsWithSip(matches, wcs, self.config.order, bbox)
+        rejected = numpy.zeros(len(matches), dtype=bool)
+        for rej in range(self.config.numRejIter):
+            sipObject = self._fitWcs([mm for i, mm in enumerate(matches) if not rejected[i]], wcs)
             wcs = sipObject.getNewWcs()
+            rejected = self.rejectMatches(matches, wcs, rejected)
+            if rejected.sum() == len(rejected):
+                raise RuntimeError("All matches rejected in iteration %d" % (rej + 1,))
+            if debug.plot:
+                print("Plotting fit after rejection iteration %d/%d" % (rej + 1, self.config.numRejIter))
+                self.plotFit(matches, wcs, rejected)
+        # Final fit after rejection
+        sipObject = self._fitWcs([mm for i, mm in enumerate(matches) if not rejected[i]], wcs)
+        wcs = sipObject.getNewWcs()
+        if debug.plot:
+            print("Plotting final fit")
+            self.plotFit(matches, wcs, rejected)
 
         if refCat is not None:
             self.log.info("Updating centroids in refCat")
@@ -171,6 +201,26 @@ class FitTanSipWcsTask(pipeBase.Task):
                               afwGeom.Point2D(crpix), wcs.getCDMatrix())
         return newWcs
 
+    def _fitWcs(self, matches, wcs):
+        """Fit a Wcs based on the matches and a guess Wcs"""
+        for i in range(self.config.numIter):
+            sipObject = makeCreateWcsWithSip(matches, wcs, self.config.order)
+            wcs = sipObject.getNewWcs()
+        return sipObject
+
+    def rejectMatches(self, matches, wcs, rejected):
+        """Flag deviant matches
+
+        We return a boolean numpy array indicating whether the corresponding
+        match should be rejected.  The previous list of rejections is used
+        so we can calculate uncontaminated statistics.
+        """
+        fit = [wcs.skyToPixel(m.first.getCoord()) for m in matches]
+        dx = numpy.array([ff.getX() - mm.second.getCentroid().getX() for ff, mm in zip(fit, matches)])
+        dy = numpy.array([ff.getY() - mm.second.getCentroid().getY() for ff, mm in zip(fit, matches)])
+        good = numpy.logical_not(rejected)
+        return (dx > self.config.rejSigma*dx[good].std()) | (dy > self.config.rejSigma*dy[good].std())
+
     @staticmethod
     def updateRefCentroids(wcs, refList):
         """Update centroids in a collection of reference objects, given a WCS
@@ -187,10 +237,55 @@ class FitTanSipWcsTask(pipeBase.Task):
     def updateSourceCoords(wcs, sourceList):
         """Update coords in a collection of sources, given a WCS
         """
-
         if len(sourceList) < 1:
             return
         schema = sourceList[1].schema
         srcCoordKey = afwTable.CoordKey(schema["coord"])
         for src in sourceList:
             src.set(srcCoordKey, wcs.pixelToSky(src.getCentroid()))
+
+    def plotFit(self, matches, wcs, rejected):
+        """Plot the fit
+
+        We create four plots, for all combinations of (dx, dy) against
+        (x, y).  Good points are black, while rejected points are red.
+        """
+        import matplotlib.pyplot as plt
+
+        fit = [wcs.skyToPixel(m.first.getCoord()) for m in matches]
+        x1 = numpy.array([ff.getX() for ff in fit])
+        y1 = numpy.array([ff.getY() for ff in fit])
+        x2 = numpy.array([m.second.getCentroid().getX() for m in matches])
+        y2 = numpy.array([m.second.getCentroid().getY() for m in matches])
+
+        dx = x1 - x2
+        dy = y1 - y2
+
+        good = numpy.logical_not(rejected)
+
+        figure = plt.figure()
+        axes = figure.add_subplot(2, 2, 1)
+        axes.plot(x2[good], dx[good], 'ko')
+        axes.plot(x2[rejected], dx[rejected], 'ro')
+        axes.set_xlabel("x")
+        axes.set_ylabel("dx")
+
+        axes = figure.add_subplot(2, 2, 2)
+        axes.plot(x2[good], dy[good], 'ko')
+        axes.plot(x2[rejected], dy[rejected], 'ro')
+        axes.set_xlabel("x")
+        axes.set_ylabel("dy")
+
+        axes = figure.add_subplot(2, 2, 3)
+        axes.plot(y2[good], dx[good], 'ko')
+        axes.plot(y2[rejected], dx[rejected], 'ro')
+        axes.set_xlabel("y")
+        axes.set_ylabel("dx")
+
+        axes = figure.add_subplot(2, 2, 4)
+        axes.plot(y2[good], dy[good], 'ko')
+        axes.plot(y2[rejected], dy[rejected], 'ro')
+        axes.set_xlabel("y")
+        axes.set_ylabel("dy")
+
+        plt.show()

--- a/python/lsst/meas/astrom/matchOptimisticB.py
+++ b/python/lsst/meas/astrom/matchOptimisticB.py
@@ -269,7 +269,7 @@ class MatchOptimisticBTask(pipeBase.Task):
         usableSourceCat = afwTable.SourceCatalog(sourceCat.table)
         usableSourceCat.extend(s for s in sourceCat if sourceInfo.isUsable(s))
         numUsableSources = len(usableSourceCat)
-        self.log.info("Purged %d unsuable sources, leaving %d usable sources" % \
+        self.log.info("Purged %d unusable sources, leaving %d usable sources" % \
             (numSources - numUsableSources, numUsableSources))
 
         if len(usableSourceCat) == 0:

--- a/python/lsst/meas/astrom/matchOptimisticB.py
+++ b/python/lsst/meas/astrom/matchOptimisticB.py
@@ -364,6 +364,7 @@ class MatchOptimisticBTask(pipeBase.Task):
                         refCat,
                         sourceCat,
                         matchControl,
+                        wcs,
                         posRefBegInd,
                         verbose,
                     )

--- a/src/matchOptimisticB.cc
+++ b/src/matchOptimisticB.cc
@@ -703,7 +703,10 @@ namespace astrom {
                             std::cout << "Linear fit from match:" << std::endl;
                             std::cout << coeff[0] << " " << coeff[1] << " " << coeff[2] << std::endl;
                             std::cout << coeff[3] << " " << coeff[4] << " " << coeff[5] << std::endl;
+                            std::cout << "Determinant (max " << control.maxDeterminant << "): ";
                             std::cout << coeff[1] * coeff[5] - coeff[2] * coeff[4] - 1. << std::endl;
+                            std::cout << "Angle between axes (deg; allowed 90 +/- ";
+                            std::cout << control.allowedNonperpDeg << "): ";
                             std::cout << theta.asDegrees() << std::endl;
                         }
                         if (std::fabs(coeff[1] * coeff[5] - coeff[2] * coeff[4] - 1.) 

--- a/src/matchOptimisticB.cc
+++ b/src/matchOptimisticB.cc
@@ -696,18 +696,19 @@ namespace astrom {
                         double b = coeff[2];
                         double c = coeff[4];
                         double d = coeff[5];
-                        double theta = std::acos((a*b+c*d)/(std::sqrt(a*a+c*c)*std::sqrt(b*b+d*d))) /
-                            M_PI * 180.0;
+                        afw::geom::Angle const theta(std::acos((a*b+c*d)/
+                                                               (std::sqrt(a*a+c*c)*std::sqrt(b*b+d*d))),
+                                                     afw::geom::radians);
                         if (verbose) {
                             std::cout << "Linear fit from match:" << std::endl;
                             std::cout << coeff[0] << " " << coeff[1] << " " << coeff[2] << std::endl;
                             std::cout << coeff[3] << " " << coeff[4] << " " << coeff[5] << std::endl;
                             std::cout << coeff[1] * coeff[5] - coeff[2] * coeff[4] - 1. << std::endl;
-                            std::cout << theta << std::endl;
+                            std::cout << theta.asDegrees() << std::endl;
                         }
                         if (std::fabs(coeff[1] * coeff[5] - coeff[2] * coeff[4] - 1.) 
                                 > control.maxDeterminant ||
-                            std::fabs(theta - 90.) > control.allowedNonperpDeg ||
+                            std::fabs(theta.asDegrees() - 90) > control.allowedNonperpDeg ||
                             std::fabs(coeff[0]) > control.maxOffsetPix ||
                             std::fabs(coeff[3]) > control.maxOffsetPix) {
                             if (verbose) {

--- a/src/matchOptimisticB.cc
+++ b/src/matchOptimisticB.cc
@@ -534,7 +534,6 @@ namespace astrom {
             throw LSST_EXCEPT(pexExcept::InvalidParameterError, "posRefBegInd too big");
         }
         double const maxRotationRad = afw::geom::degToRad(control.maxRotationDeg);
-        double const allowedNonperpRad = afw::geom::degToRad(control.allowedNonperpDeg);
 
         CONST_PTR(afw::image::Wcs) tanWcs; // Undistorted Wcs, providing tangent plane
         if (wcs.hasDistortion()) {
@@ -708,7 +707,7 @@ namespace astrom {
                         }
                         if (std::fabs(coeff[1] * coeff[5] - coeff[2] * coeff[4] - 1.) 
                                 > control.maxDeterminant ||
-                            std::fabs(theta - 90.) > allowedNonperpRad ||
+                            std::fabs(theta - 90.) > control.allowedNonperpDeg ||
                             std::fabs(coeff[0]) > control.maxOffsetPix ||
                             std::fabs(coeff[3]) > control.maxOffsetPix) {
                             if (verbose) {

--- a/tests/testAstrometryTask.py
+++ b/tests/testAstrometryTask.py
@@ -91,6 +91,7 @@ class TestAstrometricSolver(utilsTests.TestCase):
         sourceCat = self.makeSourceCat(distortedWcs)
         config = measAstrom.AstrometryTask.ConfigClass()
         config.wcsFitter.order = order
+        config.wcsFitter.numRejIter = 0
         solver = measAstrom.AstrometryTask(config=config)
         results = solver.run(
             sourceCat = sourceCat,


### PR DESCRIPTION
We use the estimated distortion (in the form of a DistortedTanWcs)
to correct the source positions.  Both distortion-corrected source
and reference sky coordinates are projected using a simple linear
Wcs, and an offset applied to bring them as close together as
possible.