### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/meas/astrom/sip/CreateWcsWithSip.h
+++ b/include/lsst/meas/astrom/sip/CreateWcsWithSip.h
@@ -28,7 +28,7 @@
 
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "lsst/base.h"
 #include "Eigen/Core"
 
@@ -87,8 +87,8 @@ template<class MatchT>
 class CreateWcsWithSip {
 public:
 
-    typedef boost::shared_ptr<CreateWcsWithSip> Ptr;
-    typedef boost::shared_ptr<CreateWcsWithSip const> ConstPtr;
+    typedef std::shared_ptr<CreateWcsWithSip> Ptr;
+    typedef std::shared_ptr<CreateWcsWithSip const> ConstPtr;
 
     /**
      Construct a CreateWcsWithSip

--- a/include/lsst/meas/astrom/sip/CreateWcsWithSip.h
+++ b/include/lsst/meas/astrom/sip/CreateWcsWithSip.h
@@ -26,9 +26,9 @@
 #ifndef CREATE_WCS_WITH_SIP
 #define CREATE_WCS_WITH_SIP
 
+#include <memory>
 #include <vector>
 
-#include <memory>
 #include "lsst/base.h"
 #include "Eigen/Core"
 

--- a/include/lsst/meas/astrom/sip/LeastSqFitter1d.h
+++ b/include/lsst/meas/astrom/sip/LeastSqFitter1d.h
@@ -27,9 +27,9 @@
 #define LEAST_SQ_FITTER_1D
 
 #include <cstdio>
+#include <memory>
 #include <vector>
 
-#include <memory>
 #include "Eigen/Core"
 #include "Eigen/SVD"
 

--- a/include/lsst/meas/astrom/sip/LeastSqFitter1d.h
+++ b/include/lsst/meas/astrom/sip/LeastSqFitter1d.h
@@ -29,7 +29,7 @@
 #include <cstdio>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "Eigen/Core"
 #include "Eigen/SVD"
 
@@ -94,7 +94,7 @@ private:
     Eigen::JacobiSVD<Eigen::MatrixXd> _svd;
     Eigen::VectorXd _par;
 
-    std::vector<boost::shared_ptr<FittingFunc> > _funcArray;
+    std::vector<std::shared_ptr<FittingFunc> > _funcArray;
 };
 
 //The .cc part
@@ -244,7 +244,7 @@ template<class FittingFunc> void LeastSqFitter1d<FittingFunc>::initFunctions() {
     
     coeff.push_back(1.0);
     for (int i = 0; i < _order; ++i) {
-        boost::shared_ptr<FittingFunc> p(new FittingFunc(coeff));
+        std::shared_ptr<FittingFunc> p(new FittingFunc(coeff));
         _funcArray.push_back(p);
         coeff[i] = 0.0;
         coeff.push_back(1.0);  //coeff now looks like [0,0,...,0,1]

--- a/include/lsst/meas/astrom/sip/LeastSqFitter2d.h
+++ b/include/lsst/meas/astrom/sip/LeastSqFitter2d.h
@@ -30,7 +30,7 @@
 #include <cstdio>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "Eigen/Core"
 #include "Eigen/SVD"
 
@@ -97,7 +97,7 @@ private:
     Eigen::JacobiSVD<Eigen::MatrixXd> _svd;
     Eigen::VectorXd _par;
 
-    std::vector<boost::shared_ptr<FittingFunc> > _funcArray;
+    std::vector<std::shared_ptr<FittingFunc> > _funcArray;
         
         
 };
@@ -266,7 +266,7 @@ template<class FittingFunc> void LeastSqFitter2d<FittingFunc>::initFunctions() {
     
     coeff.push_back(1);
     for (int i = 0; i < _order; ++i) {
-        boost::shared_ptr<FittingFunc> p(new FittingFunc(coeff));
+        std::shared_ptr<FittingFunc> p(new FittingFunc(coeff));
         _funcArray.push_back(p);
         
         coeff[i] = 0;

--- a/include/lsst/meas/astrom/sip/LeastSqFitter2d.h
+++ b/include/lsst/meas/astrom/sip/LeastSqFitter2d.h
@@ -28,9 +28,9 @@
 
 
 #include <cstdio>
+#include <memory>
 #include <vector>
 
-#include <memory>
 #include "Eigen/Core"
 #include "Eigen/SVD"
 

--- a/include/lsst/meas/astrom/sip/MatchSrcToCatalogue.h
+++ b/include/lsst/meas/astrom/sip/MatchSrcToCatalogue.h
@@ -58,8 +58,8 @@ namespace sip {
 class MatchSrcToCatalogue{
 public:
 
-    typedef boost::shared_ptr<MatchSrcToCatalogue> Ptr;
-    typedef boost::shared_ptr<MatchSrcToCatalogue const> ConstPtr;
+    typedef std::shared_ptr<MatchSrcToCatalogue> Ptr;
+    typedef std::shared_ptr<MatchSrcToCatalogue const> ConstPtr;
     
     MatchSrcToCatalogue(afw::table::SimpleCatalog const& catSet,
                         afw::table::SourceCatalog const& imgSet,       

--- a/python/lsst/meas/astrom/astrometry_net.i
+++ b/python/lsst/meas/astrom/astrometry_net.i
@@ -39,7 +39,7 @@ Python interface to Astrometry.net
 #include <vector>
 #include <set>
 #include "boost/cstdint.hpp"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "boost/format.hpp"
 
 #include "lsst/meas/astrom/detail/utils.h"
@@ -149,7 +149,7 @@ void finalize() {
     start_an_logging();
     %}
 
-%include "boost_shared_ptr.i"
+%include "std_shared_ptr.i"
 %include "lsst/p_lsstSwig.i"
 %include "lsst/base.h"
 %import "lsst/daf/base/baseLib.i"
@@ -311,7 +311,7 @@ void set_an_log(PTR(pexLog::Log) newlog);
 
     PTR(lsst::daf::base::PropertyList) getSolveStats() {
         // Gather solve stats...
-        PTR(dafBase::PropertyList) qa = boost::make_shared<dafBase::PropertyList>();
+        PTR(dafBase::PropertyList) qa = std::make_shared<dafBase::PropertyList>();
         // FIXME -- Ticket #1875 prevents dotted-names from working with toString().
         qa->set("meas_astrom*an*n_tried", $self->numtries);
         qa->set("meas_astrom*an*n_matched", $self->nummatches);

--- a/python/lsst/meas/astrom/astrometry_net.i
+++ b/python/lsst/meas/astrom/astrometry_net.i
@@ -36,10 +36,10 @@ Python interface to Astrometry.net
 #undef debug
     }
 
-#include <vector>
-#include <set>
-#include "boost/cstdint.hpp"
 #include <memory>
+#include <set>
+#include <vector>
+#include "boost/cstdint.hpp"
 #include "boost/format.hpp"
 
 #include "lsst/meas/astrom/detail/utils.h"

--- a/src/matchOptimisticB.cc
+++ b/src/matchOptimisticB.cc
@@ -248,12 +248,12 @@ namespace {
             gsl_vector_view b = gsl_vector_view_array(b_data.get(), ncoeff);
             gsl_vector_view c = gsl_vector_view_array(c_data.get(), ncoeff);
 
-            boost::shared_ptr<gsl_vector> x(gsl_vector_alloc(ncoeff), gsl_vector_free);
-            boost::shared_ptr<gsl_vector> y(gsl_vector_alloc(ncoeff), gsl_vector_free);
+            std::shared_ptr<gsl_vector> x(gsl_vector_alloc(ncoeff), gsl_vector_free);
+            std::shared_ptr<gsl_vector> y(gsl_vector_alloc(ncoeff), gsl_vector_free);
 
             int s;
 
-            boost::shared_ptr<gsl_permutation> p(gsl_permutation_alloc(ncoeff), gsl_permutation_free);
+            std::shared_ptr<gsl_permutation> p(gsl_permutation_alloc(ncoeff), gsl_permutation_free);
 
             gsl_linalg_LU_decomp(&a.matrix, p.get(), &s);
             gsl_linalg_LU_solve(&a.matrix, p.get(), &b.vector, x.get());
@@ -442,7 +442,7 @@ namespace {
             proxyPairIter != proxyPairList.get<insertionOrderTag>().end(); ++proxyPairIter) {
             matPair.push_back(afwTable::ReferenceMatch(
                 proxyPairIter->first.record,
-                boost::static_pointer_cast<afwTable::SourceRecord>(proxyPairIter->second.record),
+                std::static_pointer_cast<afwTable::SourceRecord>(proxyPairIter->second.record),
                 proxyPairIter->distance
             ));
         }
@@ -557,7 +557,7 @@ namespace astrom {
             }
             refCenter /= posRefCat.size();
 
-            tanWcs = boost::make_shared<afw::image::Wcs>(
+            tanWcs = std::make_shared<afw::image::Wcs>(
                 afw::coord::IcrsCoord(afw::geom::Point3D(refCenter)).getPosition(),
                 afw::geom::Point2D(srcCenter),
                 wcs.getCDMatrix()

--- a/tests/testlsf1d.cc
+++ b/tests/testlsf1d.cc
@@ -32,7 +32,7 @@ using namespace std;
 #include <cmath>
 #include <cstdio>
 #include <cassert>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "Eigen/Core"
 #include "lsst/afw/math/FunctionLibrary.h"
 

--- a/tests/testlsf2d.cc
+++ b/tests/testlsf2d.cc
@@ -33,7 +33,7 @@ using namespace std;
 #include <vector>
 #include <cmath>
 #include <iostream>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "Eigen/Core"
 #include "Eigen/SVD"
 #include "lsst/afw/math/FunctionLibrary.h"


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
