### PR TITLE
ANetAstrometryConfig: add alias refObjLoader

### DIFF
--- a/python/lsst/meas/astrom/anetAstrometry.py
+++ b/python/lsst/meas/astrom/anetAstrometry.py
@@ -48,6 +48,11 @@ class ANetAstrometryConfig(pexConfig.Config):
     rejectIter = pexConfig.RangeField(dtype=int, default=3, doc="Rejection iterations for Wcs fitting",
                                       min=0)
 
+    @property
+    def refObjLoader(self):
+        """An alias, for a uniform interface with the standard AstrometryTask"""
+        return self.solver
+
 
     ## \addtogroup LSST_task_documentation
     ## \{


### PR DESCRIPTION
ANetAstrometryConfig names the 'refObjLoader' as 'solver', but users
(specifically, when getting the match metadata) can refer to it as
'refObjLoader'. This alias makes that work and allows us to use
astrometry.net again.