### PR TITLE
DM-7741: Logging framework migration

### DIFF
--- a/examples/imsimPlots.py
+++ b/examples/imsimPlots.py
@@ -5,8 +5,8 @@ from math import hypot
 import lsst.pex.policy as policy
 import lsst.meas.astrom as measAstrom
 import lsst.afw.image as afwImage
-from lsst.pex.logging import Log
 from lsst.afw.coord import DEGREES
+from lsst.log import Log
 import lsst.meas.algorithms.utils as maUtils
 
 import wcsPlots
@@ -94,8 +94,8 @@ def plotsForField(inButler, keys, fixup, plots=None, prefix=''):
     # ref sources
     W, H = calexp.getWidth(), calexp.getHeight()
 
-    log = Log.getDefaultLog()
-    log.setThreshold(Log.DEBUG)
+    log = Log.getDefaultLogger()
+    log.setLevel(Log.DEBUG)
 
     kwargs = {}
     if fixup:

--- a/examples/queryReferenceCatalog.py
+++ b/examples/queryReferenceCatalog.py
@@ -4,8 +4,8 @@ import sys
 
 import lsst.pex.policy as policy
 import lsst.meas.astrom as measAstrom
-from lsst.pex.logging import Log
 import lsst.afw.geom as afwGeom
+from lsst.log import Log
 
 
 def main():
@@ -23,8 +23,8 @@ def main():
     dec = float(args[1])
     radius = float(args[2])
 
-    log = Log.getDefaultLog()
-    log.setThreshold(Log.DEBUG)
+    log = Log.getDefaultLogger()
+    log.setLevel(Log.DEBUG)
     pol = policy.Policy()
     pol.set('matchThreshold', 30)
     solver = measAstrom.createSolver(pol, log)

--- a/examples/ticket2710.py
+++ b/examples/ticket2710.py
@@ -10,7 +10,7 @@ import os
 import lsst.meas.astrom as measAstrom
 import lsst.afw.table as afwTable
 import lsst.afw.image as afwImage
-import lsst.pex.logging as pexLog
+from lsst.log import Log
 
 import pyfits
 
@@ -49,7 +49,7 @@ def showSipSolutions(srcs, wcs0, andDir, x0, y0, W, H, filterName,
 
     # Set up meas_astrom
     conf = measAstrom.ANetBasicAstrometryConfig(sipOrder=4)
-    ast = measAstrom.ANetBasicAstrometryTask(conf, andConfig, logLevel=pexLog.Log.DEBUG)
+    ast = measAstrom.ANetBasicAstrometryTask(conf, andConfig, logLevel=Log.DEBUG)
 
     # What reference sources are in the original WCS
     refs = ast.getReferenceSourcesForWcs(wcs0, **imargs)
@@ -57,7 +57,7 @@ def showSipSolutions(srcs, wcs0, andDir, x0, y0, W, H, filterName,
 
     # How does a straight TAN solution look?
     conf2 = measAstrom.ANetBasicAstrometryConfig(sipOrder=4, calculateSip=False)
-    ast2 = measAstrom.ANetBasicAstrometryTask(conf2, andConfig, logLevel=pexLog.Log.DEBUG)
+    ast2 = measAstrom.ANetBasicAstrometryTask(conf2, andConfig, logLevel=Log.DEBUG)
     solve = ast2.determineWcs2(srcs, **imargs)
     tanwcs = solve.tanWcs
 

--- a/include/lsst/meas/astrom/sip/CreateWcsWithSip.h
+++ b/include/lsst/meas/astrom/sip/CreateWcsWithSip.h
@@ -36,7 +36,6 @@
 #include "lsst/afw/geom/Box.h"
 #include "lsst/afw/geom/Point.h"
 #include "lsst/afw/geom/Angle.h"
-#include "lsst/pex/logging/Log.h"
 
 namespace lsst { 
     namespace afw {
@@ -155,8 +154,6 @@ public:
 
 private:
 
-    lsst::pex::logging::Log _log;
-    
     std::vector<MatchT> const _matches;
     afw::geom::Box2I mutable _bbox;
     int _ngrid;                         // grid size to calculate inverse SIP coefficients (1-D)

--- a/python/lsst/meas/astrom/sip/sipLib.i
+++ b/python/lsst/meas/astrom/sip/sipLib.i
@@ -32,7 +32,6 @@ Python interface to lsst::afw::meas::astrom::sip classes
 %module(package="lsst.meas.astrom.sip",docstring=sipLib_DOCSTRING) sipLib
 
 %{
-#include "lsst/pex/logging/FileDestination.h"
 #include "lsst/afw/math/FunctionLibrary.h"
 #include "lsst/meas/astrom/sip/LeastSqFitter1d.h"
 #include "lsst/meas/astrom/sip/LeastSqFitter2d.h"

--- a/python/lsst/meas/astrom/verifyWcs.py
+++ b/python/lsst/meas/astrom/verifyWcs.py
@@ -27,11 +27,14 @@ import lsst.afw.detection as afwDetection
 import lsst.afw.geom as afwGeom
 import lsst.afw.math as afwMath
 import lsst.meas.algorithms as measAlg
-
+from lsst.log import Log
 
 def checkMatches(srcMatchSet, exposure, log=None):
     if not exposure:
         return {}
+
+    if log is None:
+        log = Log.getLogger("meas.astrom.verifyWcs.checkMatches")
 
     im = exposure.getMaskedImage().getImage()
     width, height = im.getWidth(), im.getHeight()
@@ -66,7 +69,7 @@ def checkMatches(srcMatchSet, exposure, log=None):
         try:
             cellSet.insertCandidate(measAlg.PsfCandidateF(csrc, exposure.getMaskedImage()))
         except Exception as e:
-            log.log(log.WARN, str(e))
+            log.warn(str(e))
 
     ncell = len(cellSet.getCellList())
     nobj = np.ndarray(ncell, dtype='i')
@@ -93,10 +96,9 @@ def checkMatches(srcMatchSet, exposure, log=None):
 
             j += 1
 
-        if log:
-            log.log(log.DEBUG, "%s %-30s  %8s  dx,dy = %5.2f,%5.2f  rms_x,y = %5.2f,%5.2f" %
-                    (cell.getLabel(), cell.getBBox(), ("nobj=%d" % cell.size()),
-                     dx.mean(), dy.mean(), dx.std(), dy.std()))
+        log.debug("%s %-30s  %8s  dx,dy = %5.2f,%5.2f  rms_x,y = %5.2f,%5.2f",
+                  cell.getLabel(), cell.getBBox(), ("nobj=%d" % cell.size()),
+                  dx.mean(), dy.mean(), dx.std(), dy.std())
 
     nobj.sort()
 

--- a/src/sip/CreateWcsWithSip.cc
+++ b/src/sip/CreateWcsWithSip.cc
@@ -32,8 +32,12 @@
 #include "lsst/afw/geom/Angle.h"
 #include "lsst/afw/math/Statistics.h"
 #include "lsst/afw/image/TanWcs.h"
-#include "lsst/pex/logging/Log.h"
+#include "lsst/log/Log.h"
 #include "lsst/meas/astrom/makeMatchStatistics.h"
+
+namespace {
+LOG_LOGGER _log = LOG_GET("meas.astrom.sip");
+}
 
 namespace lsst { 
 namespace meas { 
@@ -47,7 +51,6 @@ namespace afwImg   = lsst::afw::image;
 namespace afwDet   = lsst::afw::detection;
 namespace afwMath  = lsst::afw::math;
 namespace afwTable = lsst::afw::table;
-namespace pexLog   = lsst::pex::logging;
 
 namespace {
 /*
@@ -111,7 +114,6 @@ CreateWcsWithSip<MatchT>::CreateWcsWithSip(
     afwGeom::Box2I const& bbox,
     int const ngrid
 ):
-    _log(pexLog::Log(pexLog::Log::getDefaultLog(), "meas.astrom.sip")),
     _matches(matches),
     _bbox(bbox),
     _ngrid(ngrid),
@@ -293,8 +295,8 @@ void CreateWcsWithSip<MatchT>::_calculateReverseMatrices() {
     // wcs->getPixelOrigin() returns LSST-style (0-indexed) pixel coords.
     afwGeom::Point2D crpix = _newWcs->getPixelOrigin();
 
-    _log.debugf("_calcReverseMatrices: x0,y0 %i,%i, W,H %i,%i, ngrid %i, dx,dy %g,%g, CRPIX %g,%g",
-                x0, y0, _bbox.getWidth(), _bbox.getHeight(), _ngrid, dx, dy, crpix[0], crpix[1]);
+    LOGL_DEBUG(_log, "_calcReverseMatrices: x0,y0 %i,%i, W,H %i,%i, ngrid %i, dx,dy %g,%g, CRPIX %g,%g",
+               x0, y0, _bbox.getWidth(), _bbox.getHeight(), _ngrid, dx, dy, crpix[0], crpix[1]);
 
     int k = 0;
     for (int i = 0; i < _ngrid; ++i) {
@@ -317,7 +319,7 @@ void CreateWcsWithSip<MatchT>::_calculateReverseMatrices() {
 
             if ((i == 0 || i == (_ngrid-1) || i == (_ngrid/2)) &&
                 (j == 0 || j == (_ngrid-1) || j == (_ngrid/2))) {
-                _log.debugf("  x,y (%.1f, %.1f), u,v (%.1f, %.1f), U,V (%.1f, %.1f)", x, y, u, v, U[k], V[k]);
+                LOGL_DEBUG(_log, "  x,y (%.1f, %.1f), u,v (%.1f, %.1f), U,V (%.1f, %.1f)", x, y, u, v, U[k], V[k]);
             }
 
             delta1[k] = u - U[k];

--- a/ups/meas_astrom.cfg
+++ b/ups/meas_astrom.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["utils", "afw", "astrometry_net", "eigen", "log", "pex_logging"],
+    "required": ["utils", "afw", "astrometry_net", "eigen", "log"],
     "buildRequired": ["boost_test", "swig"],
 }
 

--- a/ups/meas_astrom.table
+++ b/ups/meas_astrom.table
@@ -1,7 +1,6 @@
 setupRequired(afw)
 setupRequired(log)
 setupRequired(meas_algorithms)
-setupRequired(pex_logging)
 setupRequired(pex_config)
 setupRequired(pipe_base)
 setupRequired(utils)


### PR DESCRIPTION
- Fix a few places in Python. 
- Convert C++ code to use lsst.log
- This removes pex_logging dependency for this package