### PR TITLE
meas_astrom/DM-3549: new SIP fitter

### DIFF
--- a/include/lsst/meas/astrom.h
+++ b/include/lsst/meas/astrom.h
@@ -3,5 +3,7 @@
 #define LSST_MEAS_ASTROM_H
 
 #include "lsst/meas/astrom/matchOptimisticB.h"
-
+#include "lsst/meas/astrom/PolynomialTransform.h"
+#include "lsst/meas/astrom/SipTransform.h"
+#include "lsst/meas/astrom/ScaledPolynomialTransformFitter.h"
 #endif

--- a/include/lsst/meas/astrom/PolynomialTransform.h
+++ b/include/lsst/meas/astrom/PolynomialTransform.h
@@ -1,0 +1,257 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * Copyright 2016 LSST/AURA
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+#ifndef LSST_MEAS_ASTROM_PolynomialTransform_INCLUDED
+#define LSST_MEAS_ASTROM_PolynomialTransform_INCLUDED
+
+#include "ndarray/eigen.h"
+#include "lsst/afw/geom/AffineTransform.h"
+
+namespace lsst { namespace meas { namespace astrom {
+
+class SipForwardTransform;
+class SipReverseTransform;
+class ScaledPolynomialTransform;
+
+/**
+ *  A 2-d coordinate transform represented by a pair of standard polynomials
+ *  (one for each coordinate).
+ *
+ *  PolynomialTransform instances should be confined to a single thread.
+ */
+class PolynomialTransform {
+public:
+
+    /**
+     *  Convert a ScaledPolynomialTransform to an equivalent PolynomialTransform.
+     */
+    static PolynomialTransform convert(ScaledPolynomialTransform const & other);
+
+    /**
+     *  Convert a SipForwardTransform to an equivalent PolynomialTransform.
+     */
+    static PolynomialTransform convert(SipForwardTransform const & other);
+
+    /**
+     *  Convert a SipReverseTransform to an equivalent PolynomialTransform.
+     */
+    static PolynomialTransform convert(SipReverseTransform const & other);
+
+    /**
+     *  Construct a new transform from existing coefficient arrays.
+     *
+     *  For both input arguments, the array element at [p, q] corresponds
+     *  to the polynomial term x^p y^q.
+     *
+     *  Both arrays are expected be square and triangular; if N is the
+     *  order of the transform, both arrays should be (N+1)x(N+1), and
+     *  elements with p + q > N should be zero.
+     */
+    PolynomialTransform(
+        ndarray::Array<double const,2,2> const & xCoeffs,
+        ndarray::Array<double const,2,2> const & yCoeffs
+    );
+
+    /**
+     *  Copy constructor.
+     *
+     *  Coefficient arrays are deep-copied.
+     */
+    PolynomialTransform(PolynomialTransform const & other);
+
+    /**
+     *  Move constructor.
+     *
+     *  Coefficient arrays are moved.
+     */
+    PolynomialTransform(PolynomialTransform && other);
+
+    /**
+     *  Copy assignment.
+     *
+     *  Coefficient arrays are deep-copied.
+     */
+    PolynomialTransform & operator=(PolynomialTransform const & other);
+
+    /**
+     *  Move constructor.
+     *
+     *  Coefficient arrays are moved.
+     */
+    PolynomialTransform & operator=(PolynomialTransform && other);
+
+    /// Lightweight swap.
+    void swap(PolynomialTransform & other);
+
+    /// Return the order of the polynomials.
+    int getOrder() const { return _xCoeffs.rows() - 1; }
+
+    /**
+     * 2-D polynomial coefficients that compute the output x coordinate.
+     *
+     * Indexing the result by [p][q] gives the coefficient of
+     * @f$x_{\mathrm{in}}^p\,y_{\mathrm{in}}^q@f$.
+     */
+    ndarray::Array<double const,2,2> getXCoeffs() const { return _xCoeffs.shallow(); }
+
+    /**
+     * 2-D polynomial coefficients that compute the output x coordinate.
+     *
+     * Indexing the result by [p][q] gives the coefficient of
+     * @f$x_{\mathrm{in}}^p\,y_{\mathrm{in}}^q@f$.
+     */
+    ndarray::Array<double const,2,2> getYCoeffs() const { return _yCoeffs.shallow(); }
+
+    /**
+     * Return an approximate affine transform at the given point.
+     */
+    afw::geom::AffineTransform linearize(afw::geom::Point2D const & in) const;
+
+    /**
+     * Apply the transform to a point.
+     */
+    afw::geom::Point2D operator()(afw::geom::Point2D const & in) const;
+
+private:
+
+    PolynomialTransform(int order);
+
+    friend PolynomialTransform compose(afw::geom::AffineTransform const & t1, PolynomialTransform const & t2);
+    friend PolynomialTransform compose(PolynomialTransform const & t1, afw::geom::AffineTransform const & t2);
+    friend class ScaledPolynomialTransformFitter;
+    friend class SipForwardTransform;
+    friend class SipReverseTransform;
+    friend class ScaledPolynomialTransform;
+
+    ndarray::EigenView<double,2,2> _xCoeffs;
+    ndarray::EigenView<double,2,2> _yCoeffs;
+    mutable Eigen::VectorXd _u; // workspace for operator() and linearize
+    mutable Eigen::VectorXd _v;
+};
+
+/**
+ *  A 2-d coordinate transform represented by a lazy composition of an AffineTransform,
+ *  a PolynomialTransform, and another AffineTransform.
+ *
+ *  ScaledPolynomialTransform instances should be confined to a single thread.
+ */
+class ScaledPolynomialTransform {
+public:
+
+    /**
+     *  Convert a PolynomialTransform to an equivalent ScaledPolynomialTransform.
+     *
+     *  This simply inserts identity AffineTransforms before and after applying
+     *  the given PolynomialTransform.
+     */
+    static ScaledPolynomialTransform convert(PolynomialTransform const & poly);
+
+    /**
+     *  Convert a SipForwardTransform to an equivalent ScaledPolynomialTransform.
+     *
+     *  The input transform's CRPIX offset and CD matrix scaling are used to define
+     *  the input and output affine transforms, respectively, leaving the polynomial
+     *  coefficients unmodified.
+     */
+    static ScaledPolynomialTransform convert(SipForwardTransform const & sipForward);
+
+    /**
+     *  Convert a SipForwardTransform to an equivalent ScaledPolynomialTransform.
+     *
+     *  The input transform's CD matrix scaling and CRPIX offset are used to define
+     *  the input and output affine transforms, respectively, leaving the polynomial
+     *  coefficients unmodified.
+     */
+    static ScaledPolynomialTransform convert(SipReverseTransform const & sipReverse);
+
+    /**
+     *  Construct a new ScaledPolynomialTransform from its constituents.
+     *
+     *  @param[in]  poly           A PolynomialTransform to be applied to points.
+     *                             after the inputScaling transform.
+     *  @param[in]  inputScaling   An AffineTransform to be applied immediately
+     *                             to input points.
+     *  @param[in]  outputScalingInverse  An AffineTransform to be applied to points
+     *                                    after the PolynomialTransform.
+     */
+    ScaledPolynomialTransform(
+        PolynomialTransform const & poly,
+        afw::geom::AffineTransform const & inputScaling,
+        afw::geom::AffineTransform const & outputScalingInverse
+    );
+
+    ScaledPolynomialTransform(ScaledPolynomialTransform const & other) = default;
+
+    ScaledPolynomialTransform(ScaledPolynomialTransform && other) = default;
+
+    ScaledPolynomialTransform & operator=(ScaledPolynomialTransform const & other) = default;
+
+    ScaledPolynomialTransform & operator=(ScaledPolynomialTransform && other) = default;
+
+    void swap(ScaledPolynomialTransform & other);
+
+    /// Return the polynomial transform applied after the input scaling.
+    PolynomialTransform const & getPoly() const { return _poly; }
+
+    /// Return the first affine transform applied to input points.
+    afw::geom::AffineTransform const & getInputScaling() const { return _inputScaling; }
+
+    /// Return the affine transform applied to points after the polynomial transform.
+    afw::geom::AffineTransform const & getOutputScalingInverse() const { return _outputScalingInverse; }
+
+    /**
+     * Return an approximate affine transform at the given point.
+     */
+    afw::geom::AffineTransform linearize(afw::geom::Point2D const & in) const;
+
+    /**
+     * Apply the transform to a point.
+     */
+    afw::geom::Point2D operator()(afw::geom::Point2D const & in) const;
+
+private:
+    friend class ScaledPolynomialTransformFitter;
+    PolynomialTransform _poly;
+    afw::geom::AffineTransform _inputScaling;
+    afw::geom::AffineTransform _outputScalingInverse;
+};
+
+/**
+ *  Return a PolynomialTransform that is equivalent to the composition t1(t2())
+ *
+ *  The returned composition would be exact in ideal arithmetic, but may suffer from
+ *  significant round-off error for high-order polynomials.
+ */
+PolynomialTransform compose(afw::geom::AffineTransform const & t1, PolynomialTransform const & t2);
+
+/**
+ *  Return a PolynomialTransform that is equivalent to the composition t1(t2())
+ *
+ *  The returned composition would be exact in ideal arithmetic, but may suffer from
+ *  significant round-off error for high-order polynomials.
+ */
+PolynomialTransform compose(PolynomialTransform const & t1, afw::geom::AffineTransform const & t2);
+
+}}} // namespace lsst::meas::astrom
+
+#endif // !LSST_MEAS_ASTROM_PolynomialTransform_INCLUDED

--- a/include/lsst/meas/astrom/ScaledPolynomialTransformFitter.h
+++ b/include/lsst/meas/astrom/ScaledPolynomialTransformFitter.h
@@ -135,7 +135,7 @@ public:
      *   - initial_{x,y}:      reference positions transformed by initialWcs.
      *   - model_{x,y}:        reference positions transformed by current
      *                         best-fit distortion.
-     *   - valid:              Flag that is set for objects that have not been
+     *   - rejected            Flag that is set for objects that have been
      *                         rejected as outliers.
      */
     static ScaledPolynomialTransformFitter fromMatches(

--- a/include/lsst/meas/astrom/ScaledPolynomialTransformFitter.h
+++ b/include/lsst/meas/astrom/ScaledPolynomialTransformFitter.h
@@ -1,0 +1,319 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * Copyright 2016 LSST/AURA
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+#ifndef LSST_MEAS_ASTROM_TanSipFitter_INCLUDED
+#define LSST_MEAS_ASTROM_TanSipFitter_INCLUDED
+
+#include "lsst/pex/config.h"
+#include "lsst/afw/geom/LinearTransform.h"
+#include "lsst/afw/image/TanWcs.h"
+#include "lsst/afw/table/Catalog.h"
+#include "lsst/afw/table/BaseRecord.h"
+#include "lsst/meas/astrom/PolynomialTransform.h"
+#include "lsst/meas/astrom/SipTransform.h"
+
+namespace lsst { namespace meas { namespace astrom {
+
+
+/**
+ *  Control object for outlier rejection in ScaledPolynomialTransformFitter.
+ *
+ *  See ScaledPolynomialTransformFitter::rejectOutliers for more information.
+ */
+class OutlierRejectionControl {
+public:
+
+    OutlierRejectionControl() :
+        nSigma(3), nClipMin(1), nClipMax(5)
+    {}
+
+    LSST_CONTROL_FIELD(nSigma, double, "Number of sigma to clip at.");
+
+    LSST_CONTROL_FIELD(nClipMin, int, "Always clip at least this many matches.");
+
+    LSST_CONTROL_FIELD(nClipMax, int, "Never clip more than this many matches.");
+
+};
+
+
+/**
+ *  A fitter class for scaled polynomial transforms
+ *
+ *  This class allows for iteration between actual fitting, outlier rejection,
+ *  and estimation of intrinsic scatter.  It also provides access to the
+ *  current model for debugging via an afw::table::BaseCatalog that contains
+ *  the input values, output values, and the best-fit-transformed input values.
+ *
+ *  ScaledPolynomialTransformFitter has two public construction methods:
+ *
+ *   - fromMatches fits a transform that maps intermediate world coordinates
+ *     to pixel coordinates, using as inputs a match of reference coordinates
+ *     to measured source positions.  This sets up the fitter to do outlier
+ *     rejection and intrinsic scatter estimation.
+ *
+ *   - fromGrid fits an inverse to an existing transform, using the
+ *     to-be-inverted transform to populate a grid of positions.  Because the
+ *     to-be-inverted transform is assumed to be known exactly, fitters
+ *     initialized with this method have no need for outlier rejection or
+ *     scatter estimation.
+ *
+ *  In either case, the fitter creates affine transforms that map the input
+ *  and output data points onto [-1, 1].  It then fits a polynomial
+ *  transform that, when composed with the input scaling transform and the
+ *  inverse of the output scaling transform, maps the input data points to the
+ *  output data points.
+ *
+ *  The fitter can be used in an outlier-rejection loop with the following
+ *  pattern (with user-defined convergence criteria):
+ *  @code
+ *  while (true) {
+ *      fitter.fit();
+ *      if (converged) break;
+ *      fitter.updateModel();
+ *      fitter.computeIntrinsicScatter();
+ *      fitter.rejectOutliers();
+ *  }
+ *  @endcode
+ *  This pattern fits a model, uses that model to transform the input
+ *  points, estimates intrinsic scatter from the differences between
+ *  model-transformed points and output data points, and finally rejects
+ *  outliers by sigma-clipping those differences before repeating.
+ *
+ *  ScaledPolynomialTransformFitter instances should be confined to a single thread.
+ */
+class ScaledPolynomialTransformFitter {
+public:
+
+    /**
+     *  Initialize a fit from intermediate world coordinates to pixels using
+     *  source/reference matches.
+     *
+     *  @param[in] maxOrder         Maximum polynomial order for the fit.
+     *
+     *  @param[in] matches          Vector of source-reference matches.
+     *                              The centroids and centroid errors from the
+     *                              sources are used, along with the coords
+     *                              from the reference objects.
+     *
+     *  @param[in] initialWcs       Initial WCS, used to transform reference
+     *                              positions to intermediate world coordinates and
+     *                              populate the "ref" field in the data catalog.
+     *
+     *  @param[in] intrinsicScatter Initial intrinsic scatter to be added in
+     *                              quadrature with source measurement errors in
+     *                              setting the uncertainty on each match.
+     *
+     *  This initializes the data catalog with the following fields:
+     *   - ref_id:             reference object ID
+     *   - src_id:             source ID from the match
+     *   - src_{x,y}:          source position in pixels
+     *   - src_{xSigma,ySigma,x_y_Cov}:  uncertainty on source positions,
+     *                         including measurement errors and the inferred
+     *                         intrinsic scatter.
+     *   - intermediate_{x,y}: reference positions in intermediate world
+     *                         coordinates.
+     *   - initial_{x,y}:      reference positions transformed by initialWcs.
+     *   - model_{x,y}:        reference positions transformed by current
+     *                         best-fit distortion.
+     *   - valid:              Flag that is set for objects that have not been
+     *                         rejected as outliers.
+     */
+    static ScaledPolynomialTransformFitter fromMatches(
+        int maxOrder,
+        afw::table::ReferenceMatchVector const & matches,
+        afw::image::Wcs const & initialWcs,
+        double intrinsicScatter
+    );
+
+    /**
+     *  Initialize a fit that inverts an existing transform by evaluating and
+     *  fitting to points on a grid.
+     *
+     *  @param[in] maxOrder   Maximum polynomial order for the fit.
+     *
+     *  @param[in] bbox       Bounding box for the grid in the input
+     *                        coordinates of the toInvert transform (or
+     *                        equivalently the output coordinates of the
+     *                        transform to be fit).
+     *
+     *  @param[in] nGridX     Number of grid points in the X direction.
+     *
+     *  @param[in] nGridY     Number of grid points in the Y direction.
+     *
+     *  @param[in] toInvert   Transform to invert
+     *
+     *  This initializes the data catalog with the following fields:
+     *   - output:  grid positions passed as input to the toInvert transform,
+     *              treated as output data points when fitting its inverse.
+     *   - input:   grid positions generated as the output of the toInvert
+     *              transform, treated as input data points when fitting its
+     *              inverse.
+     *   - model:   best-fit-transformed input points.
+     *
+     *  The updateIntrinsicScatter and rejectOutliers methods cannot be used
+     *  on fitters initialized using this method.
+     */
+    static ScaledPolynomialTransformFitter fromGrid(
+        int maxOrder,
+        afw::geom::Box2D const & bbox,
+        int nGridX, int nGridY,
+        ScaledPolynomialTransform const & toInvert
+    );
+
+    /**
+     *  Perform a linear least-squares fit of the polynomial coefficients.
+     *
+     *  @param[in]  order    The maximum order of the polynomial transform.
+     *                       If negative (the default) the maxOrder from
+     *                       construction is used.
+     *
+     *  After fitting, updateModel() should be called to apply the model
+     *  transform to the input points if the user wants to make use of the
+     *  data catalog for diagnostics.  Calling fit() alone is sufficient if
+     *  the user is only interested in getting the model transform itself.
+     */
+    void fit(int order=-1);
+
+    /**
+     *  Update the 'model' field in the data catalog using the current best-
+     *  fit transform.
+     *
+     *  Should be called after fit() and before updateIntrinsicScatter() if
+     *  the fitter is being used in an outlier-rejection loop.
+     */
+    void updateModel();
+
+    /**
+     *  Infer the intrinsic scatter in the offset between the data points and
+     *  the best-fit model, and update the uncertainties accordingly.
+     *
+     *  The scatter is calculated as the RMS scatter that maximizes the
+     *  likelihood of the current positional offsets (assumed fixed) assuming
+     *  the per-data-point uncertainties are the quadrature sum of the
+     *  intrinsic scatter and that source's centroid measurement uncertainty.
+     *
+     *  Should be called after updateModel() and before rejectOutliers() if
+     *  the fitter is being used in an outlier-rejection loop.
+     */
+    double updateIntrinsicScatter();
+
+    /**
+     *  Return the current estimate of the intrinsic scatter.
+     *
+     *  Because the intrinsic scatter is included in the uncertainty used in
+     *  both the fit and outlier rejection, this may be called either before
+     *  updateIntrinsicScatter() to obtain the scatter used in the last such
+     *  operation or after updateIntrinsicScatter() to obtain the scatter to
+     *  be used in the next operation.
+     */
+    double getIntrinsicScatter() const { return _intrinsicScatter; }
+
+    /**
+     *  Mark outliers in the data catalog using sigma clipping.
+     *
+     *  A data point is declare an outlier if:
+     *   - the offset between the model prediction and the data position,
+     *     weighted by the uncertainty (including inferred intrinsic scatter)
+     *     of that point exceeds ctrl.nSigma
+     *   - the number of points already with larger weighted offsets is less
+     *     than ctrl.nClipMax.
+     *  In addition, the worst (in weighted offset) ctrl.nClipMin data points
+     *  are always rejected.
+     *
+     *  @return A pair of the smallest rejected weighted offset (units of sigma)
+     *          and the number of point rejected.
+     *
+     *  Should be called after updateIntrinsicScatter() and before fit() if
+     *  the fitter is being used in an outlier rejection loop.
+     */
+    std::pair<double,size_t> rejectOutliers(OutlierRejectionControl const & ctrl);
+
+    /**
+     *  Return a catalog of data points and model values for diagnostic purposes.
+     *
+     *  The values in the returned catalog should not be modified by the user.
+     *
+     *  For information about the schema, either introspect it programmatically
+     *  or see fromMatches and fromGrid.
+     */
+    afw::table::BaseCatalog const & getData() const { return _data; }
+
+    /**
+     *  Return the best-fit transform
+     *
+     *  If f is an instance of this class, then for an
+     *  arbitrary point p:
+     *  @code
+     *  f.getTransform()(p) == f.getOutputScaling().invert()(f.getPoly()(f.getInputScaling()(p)))
+     *  @endcode
+     */
+    ScaledPolynomialTransform const & getTransform() const { return _transform; }
+
+    /**
+     *  Return the polynomial part of the best-fit transform.
+     */
+    PolynomialTransform const & getPoly() const { return _transform.getPoly(); }
+
+    /**
+     *  Return the input scaling transform that maps input data points to [-1, 1].
+     */
+    afw::geom::AffineTransform const & getInputScaling() const { return _transform.getInputScaling(); }
+
+    /**
+     *  Return the output scaling transform that maps output data points to [-1, 1].
+     */
+    afw::geom::AffineTransform const & getOutputScaling() const { return _outputScaling; }
+
+private:
+
+    class Keys;
+
+    ScaledPolynomialTransformFitter(
+        afw::table::BaseCatalog const & data,
+        Keys const & keys,
+        int maxOrder,
+        double intrinsicScatter,
+        afw::geom::AffineTransform const & inputScaling,
+        afw::geom::AffineTransform const & outputScaling
+    );
+
+    double computeIntrinsicScatter() const;
+
+    // Normally it's not safe to use a reference as a data member because the
+    // class holding it can't control when the referenced object gets
+    // destroyed, but this points to one of two singletons (which never get
+    // destroyed).
+    Keys const & _keys;
+    double _intrinsicScatter;
+    afw::table::BaseCatalog _data;
+    afw::geom::AffineTransform _outputScaling;
+    ScaledPolynomialTransform _transform;
+    // 2-d generalization of the Vandermonde matrix: evaluates polynomial at
+    // all data points when multiplied by a vector of packed polynomial
+    // coefficients.
+    Eigen::MatrixXd _vandermonde;
+};
+
+}}} // namespace lsst::meas::astrom
+
+#endif // !LSST_MEAS_ASTROM_TanSipFitter_INCLUDEDtr

--- a/include/lsst/meas/astrom/SipTransform.h
+++ b/include/lsst/meas/astrom/SipTransform.h
@@ -1,0 +1,372 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * Copyright 2016 LSST/AURA
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+#ifndef LSST_MEAS_ASTROM_SipTransform_INCLUDED
+#define LSST_MEAS_ASTROM_SipTransform_INCLUDED
+
+#include "lsst/afw/geom/LinearTransform.h"
+#include "lsst/meas/astrom/PolynomialTransform.h"
+
+
+namespace lsst { namespace afw { namespace image {
+
+class TanWcs;
+
+} // namespace image
+
+namespace coord {
+
+class Coord;
+
+} // namespace coord
+
+} // namespace afw
+
+namespace meas { namespace astrom {
+
+/**
+ *  Base class for SIP transform objects.
+ *
+ *  This class simply provides some getters for its derived classes.
+ *  It should not be used directly, and does not define a polymorphic
+ *  interface.
+ */
+class SipTransformBase {
+public:
+
+    /**
+     *  Return the pixel origin (CRPIX) of the transform.
+     */
+    afw::geom::Point2D const & getPixelOrigin() const { return _pixelOrigin; }
+
+    /**
+     *  Return the CD matrix of the transform.
+     */
+    afw::geom::LinearTransform const & getCDMatrix() const { return _cdMatrix; }
+
+    /**
+     *  Return the polynomial component of the transform (A,B) or (AP,BP).
+     */
+    PolynomialTransform const & getPoly() const { return _poly; }
+
+protected:
+
+    /**
+     *  Construct a SipTransformBase from its components.
+     *
+     *  See SipForwardTransform and SipReverseTransform for more extensive
+     *  definitions.
+     *
+     *  @param[in]   pixelOrigin    CRPIX @f$(u_0,v_0)@f$ (zero-indexed)
+     *  @param[in]   cdMatrix       CD matrix @f$Z@f$
+     *  @param[in]   poly           Either the forward or reverse
+     *                              SIP polynomial (depending on the derived
+     *                              class).
+     */
+    SipTransformBase(
+        afw::geom::Point2D const & pixelOrigin,
+        afw::geom::LinearTransform const & cdMatrix,
+        PolynomialTransform const & poly
+    ) : _pixelOrigin(pixelOrigin),
+        _cdMatrix(cdMatrix),
+        _poly(poly)
+    {}
+
+    SipTransformBase(SipTransformBase const & other) = default;
+    SipTransformBase(SipTransformBase && other) = default;
+    SipTransformBase & operator=(SipTransformBase const & other) = default;
+    SipTransformBase & operator=(SipTransformBase && other) = default;
+
+    void swap(SipTransformBase & other) {
+        std::swap(_pixelOrigin, other._pixelOrigin);
+        std::swap(_cdMatrix, other._cdMatrix);
+        _poly.swap(other._poly);
+    }
+
+    afw::geom::Point2D _pixelOrigin;
+    afw::geom::LinearTransform _cdMatrix;
+    PolynomialTransform _poly;
+};
+
+
+/**
+ *  A transform that maps pixel coordinates to intermediate world coordinates
+ *  according to the SIP convention.
+ *
+ *  The SIP forward transform is defined as
+ *  @f[
+ *     \left[\begin{array}{ c }
+ *       x \\
+ *       y
+ *     \end{array}\right]
+ *     = \mathbf{Z}
+ *     \left[\begin{array}{ c }
+ *       (u - u_0) + {\displaystyle\sum_{p,q}^{2 \le p + q \le N}} \mathrm{A}_{p,q} (u-u_0)^p (v-v_0)^q \\
+ *       (v - v_0) + {\displaystyle\sum_{p,q}^{2 \le p + q \le N}} \mathrm{B}_{p,q} (u-u_0)^p (v-v_0)^q
+ *     \end{array}\right]
+ *  @f]
+ *  where
+ *   - @f$(u,v)@f$ are pixel coordinates (zero-indexed).
+ *   - @f$(x,y)@f$ are "intermediate world coordinates" -- the result of
+ *     applying the gnomonic (TAN) projection at sky origin CRVAL to sky
+ *     coordinates).
+ *   - @f$\mathbf{Z}@f$ is the @f$2 \times 2@f$ linear transform (@f$\mathrm{CD}@f$) matrix.
+ *   - @f$(u_0,v_0)@f$ is the pixel origin @f$\mathrm{CRPIX}@f$ (but zero-indexed;
+ *     the FITS standard is 1-indexed).
+ *   - @f$\mathrm{A}@f$, @f$\mathrm{B}@f$ are the polynomial coefficients of
+ *     the forward transform.
+ *
+ *  The SIP convention encourages (but does not require) nulling the zeroth-
+ *  and first-order elements of
+ *  @f$\mathrm{A}@f$ and @f$\mathrm{B}@f$, which ensures the representation of
+ *  a given transform is unique.  This also makes fitting a SIP transform to
+ *  data a nonlinear operation, as well as making the conversion from standard
+ *  polynomial transforms to SIP form impossible in general.  Accordingly,
+ *  this class does not attempt to null low-order polynomial terms at all
+ *  when converting from other transforms.
+ *
+ *  SipForwardTransform instances should be confined to a single thread.
+ */
+class SipForwardTransform : public SipTransformBase {
+public:
+
+    /**
+     *  Convert a PolynomialTransform to an equivalent SipForwardTransform.
+     *
+     *  @param[in]   poly           PolynomialTransform to convert.
+     *  @param[in]   pixelOrigin    CRPIX @f$(u_0,v_0)@f$ (zero-indexed)
+     *  @param[in]   cdMatrix       CD matrix @f$Z@f$
+     */
+    static SipForwardTransform convert(
+        PolynomialTransform const & poly,
+        afw::geom::Point2D const & pixelOrigin,
+        afw::geom::LinearTransform const & cdMatrix
+    );
+
+    /**
+     *  Convert a ScaledPolynomialTransform to an equivalent SipForwardTransform.
+     *
+     *  @param[in]   scaled         ScaledPolynomialTransform to convert.
+     *  @param[in]   pixelOrigin    CRPIX @f$(u_0,v_0)@f$ (zero-indexed)
+     *  @param[in]   cdMatrix       CD matrix @f$Z@f$
+     */
+    static SipForwardTransform convert(
+        ScaledPolynomialTransform const & scaled,
+        afw::geom::Point2D const & pixelOrigin,
+        afw::geom::LinearTransform const & cdMatrix
+    );
+
+    /**
+     *  Convert a ScaledPolynomialTransform to an equivalent SipForwardTransform.
+     *
+     *  The pixel origin CRPIX and CD matrix are defined to reproduce the translation
+     *  and linear transformation in the ScaledPolynomialTransform's input and
+     *  output scalings (respectively).
+     */
+    static SipForwardTransform convert(ScaledPolynomialTransform const & scaled);
+
+    /**
+     *  Construct a SipForwardTransform from its components.
+     *
+     *  @param[in]   pixelOrigin    CRPIX @f$(u_0,v_0)@f$ (zero-indexed).
+     *  @param[in]   cdMatrix       CD matrix @f$Z@f$
+     *  @param[in]   forwardSipPoly Polynomial transform @f$(A,B)@f$
+     */
+    SipForwardTransform(
+        afw::geom::Point2D const & pixelOrigin,
+        afw::geom::LinearTransform const & cdMatrix,
+        PolynomialTransform const & forwardSipPoly
+    ) :
+        SipTransformBase(pixelOrigin, cdMatrix, forwardSipPoly)
+    {}
+
+    SipForwardTransform(SipForwardTransform const & other) = default;
+
+    SipForwardTransform(SipForwardTransform && other) = default;
+
+    SipForwardTransform & operator=(SipForwardTransform const & other) = default;
+
+    SipForwardTransform & operator=(SipForwardTransform && other) = default;
+
+    void swap(SipForwardTransform & other) {
+        SipTransformBase::swap(other);
+    }
+
+    /**
+     * Return an approximate affine transform at the given point.
+     */
+    afw::geom::AffineTransform linearize(afw::geom::Point2D const & in) const;
+
+    /**
+     * Apply the transform to a point.
+     */
+    afw::geom::Point2D operator()(afw::geom::Point2D const & uv) const;
+
+};
+
+
+/**
+ *  A transform that maps intermediate world coordinates to pixel coordinates
+ *  according to the SIP convention.
+ *
+ *  The SIP reverse transform is defined as
+ *  @f[
+ *     \left[\begin{array}{ c }
+ *       u \\
+ *       v
+ *     \end{array}\right]
+ *     = \left[\begin{array}{ c }
+ *       u_0 + U + {\displaystyle\sum_{p,q}^{0 \le p + q \le N}} \mathrm{AP}_{p,q} U^p V^q \\
+ *       v_0 + V + {\displaystyle\sum_{p,q}^{0 \le p + q \le N}} \mathrm{BP}_{p,q} U^p V^q \\
+ *     \end{array}\right]
+ *  @f]
+ *  with
+ *  @f[
+ *     \left[\begin{array}{ c }
+ *       U \\
+ *       V
+ *     \end{array}\right]
+ *     = \mathbf{Z}^{-1}
+ *     \left[\begin{array}{ c }
+ *       x \\
+ *       y
+ *     \end{array}\right]
+ *  @f]
+ *  and
+ *   - @f$(u,v)@f$ are pixel coordinates.
+ *   - @f$(x,y)@f$ are "intermediate world coordinates" -- the result of
+ *     applying the gnomonic (TAN) projection at sky origin CRVAL to sky
+ *     coordinates).
+ *   - @f$\mathbf{Z}@f$ is the @f$2 \times 2@f$ linear transform (@f$\mathrm{CD}@f$) matrix.
+ *   - @f$(u_0,v_0)@f$ is the pixel origin @f$\mathrm{CRPIX}@f$ (but zero-indexed;
+ *     the FITS standard is 1-indexed).
+ *   - @f$\mathrm{AP}@f$, @f$\mathrm{BP}@f$ are the polynomial coefficients of
+ *     the reverse transform.
+ *
+ *  SipForwardTransform instances should be confined to a single thread.
+ */
+class SipReverseTransform : public SipTransformBase {
+public:
+
+    /**
+     *  Convert a PolynomialTransform to an equivalent SipReverseTransform.
+     *
+     *  @param[in]   poly           PolynomialTransform to convert.
+     *  @param[in]   pixelOrigin    CRPIX @f$(u_0,v_0)@f$ (zero-indexed)
+     *  @param[in]   cdMatrix       CD matrix @f$Z@f$
+     */
+    static SipReverseTransform convert(
+        PolynomialTransform const & poly,
+        afw::geom::Point2D const & pixelOrigin,
+        afw::geom::LinearTransform const & cdMatrix
+    );
+
+    /**
+     *  Convert a ScaledPolynomialTransform to an equivalent SipReverseTransform.
+     *
+     *  @param[in]   scaled         ScaledPolynomialTransform to convert.
+     *  @param[in]   pixelOrigin    CRPIX @f$(u_0,v_0)@f$ (zero-indexed)
+     *  @param[in]   cdMatrix       CD matrix @f$Z@f$
+     */
+    static SipReverseTransform convert(
+        ScaledPolynomialTransform const & scaled,
+        afw::geom::Point2D const & pixelOrigin,
+        afw::geom::LinearTransform const & cdMatrix
+    );
+
+    /**
+     *  Convert a ScaledPolynomialTransform to an equivalent SipReverseTransform.
+     *
+     *  The pixel origin CRPIX and CD matrix are defined to reproduce the translation
+     *  and linear transformation in the ScaledPolynomialTransforms output and
+     *  input scalings (respectively).
+     */
+    static SipReverseTransform convert(ScaledPolynomialTransform const & scaled);
+
+    /**
+     *  Construct a SipReverseTransform from its components.
+     *
+     *  @param[in]   pixelOrigin    CRPIX @f$(u_0,v_0)@f$ (zero-indexed)
+     *  @param[in]   cdMatrix       CD matrix @f$Z@f$
+     *  @param[in]   reverseSipPoly Polynomial transform @f$(AP,BP)@f$
+     */
+    SipReverseTransform(
+        afw::geom::Point2D const & pixelOrigin,
+        afw::geom::LinearTransform const & cdMatrix,
+        PolynomialTransform const & reverseSipPoly
+    ) : SipTransformBase(pixelOrigin, cdMatrix, reverseSipPoly),
+        _cdInverse(cdMatrix.invert())
+    {}
+
+    SipReverseTransform(SipReverseTransform const & other) = default;
+
+    SipReverseTransform(SipReverseTransform && other) = default;
+
+    SipReverseTransform & operator=(SipReverseTransform const & other) = default;
+
+    SipReverseTransform & operator=(SipReverseTransform && other) = default;
+
+    void swap(SipReverseTransform & other) {
+        SipTransformBase::swap(other);
+        std::swap(_cdInverse, other._cdInverse);
+    }
+
+    /**
+     * Return an approximate affine transform at the given point.
+     */
+    afw::geom::AffineTransform linearize(afw::geom::Point2D const & in) const;
+
+    /**
+     * Apply the transform to a point.
+     */
+    afw::geom::Point2D operator()(afw::geom::Point2D const & xy) const;
+
+private:
+    friend class PolynomialTransform;
+    friend class ScaledPolynomialTransform;
+    afw::geom::LinearTransform _cdInverse;
+};
+
+/**
+ *  Create a new TAN SIP Wcs from a pair of SIP transforms and the sky origin.
+ *
+ *  @param[in]   sipForward    Mapping from pixel coordinates to intermediate
+ *                             world coordinates.
+ *  @param[in]   sipReverse    Mapping from intermediate world coordinates to
+ *                             pixel coordinates.
+ *  @param[in]   skyOrigin     Position of the gnomonic projection that maps
+ *                             sky coordinates to intermediate world coordinates
+ *                             (CRVAL).
+ *
+ *  @throw pex::exceptions::InvalidParameterError if the forward and reverse
+ *         SIP transforms have different CRPIX values or CD matrices.
+ */
+std::shared_ptr<afw::image::TanWcs> makeWcs(
+    SipForwardTransform const & sipForward,
+    SipReverseTransform const & sipReverse,
+    afw::coord::Coord const & skyOrigin
+);
+
+}}} // namespace lsst::meas::astrom
+
+#endif // !LSST_MEAS_ASTROM_SipTransform_INCLUDED

--- a/include/lsst/meas/astrom/detail/polynomialUtils.h
+++ b/include/lsst/meas/astrom/detail/polynomialUtils.h
@@ -1,0 +1,119 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * Copyright 2016 LSST/AURA
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#ifndef LSST_MEAS_ASTROM_DETAIL_polynomialUtils_h_INCLUDED
+#define LSST_MEAS_ASTROM_DETAIL_polynomialUtils_h_INCLUDED
+
+#include "Eigen/Core"
+
+namespace lsst { namespace meas { namespace astrom { namespace detail {
+
+/**
+ *  Compute the index of the first coefficient with the given order in
+ *  a packed 2-d polynomial coefficient array.
+ *
+ *  This defines the ordering as
+ *  @code
+ *  [(0,0), (0,1), (1,0), (0,2), (1,1), (2,0), ...]
+ *  @endcode
+ *  (or the same with indices swapped).
+ */
+inline int computePackedOffset(int order) {
+    return (order*(order + 1))/2;
+}
+
+/**
+ *  Compute this size of a packed 2-d polynomial coefficient array.
+ */
+inline int computePackedSize(int order) {
+    return computePackedOffset(order + 1);
+}
+
+/**
+ *  Fill an array with integer powers of x, so @f$$r[n] == r^n@f$.
+ *
+ *  When multiple powers are needed, this should be signficantly faster than
+ *  repeated calls to std::pow().
+ */
+void computePowers(Eigen::VectorXd & r, double x);
+
+/**
+ *  Return an array with integer powers of x, so @f$$r[n] == r^n@f$.
+ *
+ *  When multiple powers are needed, this should be signficantly faster than
+ *  repeated calls to std::pow().
+ */
+Eigen::VectorXd computePowers(double x, int n);
+
+
+/**
+ *  A class that computes binomial coefficients up to a certain power.
+ *
+ *  The binomial coefficient is defined as:
+ *  @f[
+ *     \left(\begin{array}{ c }
+ *       n
+ *       k
+ *     \end{array}right\)
+ *     = \frac{n!}{k!(n-k)!}
+ *  @f]
+ *  with both @f$n@f$ and @f$k@f$ nonnegative integers and @f$k \le n@f$
+ *
+ *  This class uses recurrence relations to avoid computing factorials directly,
+ *  making it both more efficient and numerically stable.
+ */
+class BinomialMatrix {
+public:
+
+    /**
+     *  Construct an object that can compute binomial coefficients with @f$n@f$
+     *  up to and including the given value.
+     */
+    explicit BinomialMatrix(int const nMax) { extend(nMax); }
+
+    /**
+     *  Return the binomial coefficient.
+     *
+     *  No error checking is performed; the behavior of this method is is
+     *  undefined if the given values do not satisfy
+     *  @code
+     *  n <= nMax && k <= n && n >=0 && k >= 0
+     *  @endcode
+     */
+    double operator()(int n, int k) const {
+        return getMatrix()(n, k);
+    }
+
+private:
+
+    static void extend(int const n);
+
+    static Eigen::MatrixXd & getMatrix();
+
+};
+
+
+}}}} // namespace lsst::meas::astrom::detail
+
+#endif // !LSST_MEAS_ASTROM_DETAIL_polynomialUtils_h_INCLUDED

--- a/python/lsst/meas/astrom/__init__.py
+++ b/python/lsst/meas/astrom/__init__.py
@@ -36,5 +36,6 @@ from .createMatchMetadata import *
 from .astromLib import *
 from .catalogStarSelector import *
 from .directMatch import *
+from .fitSipDistortion import *
 
 from .version import *

--- a/python/lsst/meas/astrom/astromLib.i
+++ b/python/lsst/meas/astrom/astromLib.i
@@ -11,16 +11,24 @@ Python interface to lsst::meas::astrom
 %{
 #include "lsst/afw/image.h"
 #include "lsst/afw/cameraGeom.h"
+#include "lsst/afw/geom.h"
 #include "lsst/afw/table.h"
 #include "lsst/afw/image/Wcs.h"
 #include "lsst/afw/image/TanWcs.h"
 #include "lsst/meas/astrom/matchOptimisticB.h"
 #include "lsst/meas/astrom/makeMatchStatistics.h"
+#include "lsst/meas/astrom/PolynomialTransform.h"
+#include "lsst/meas/astrom/SipTransform.h"
+#include "lsst/meas/astrom/ScaledPolynomialTransformFitter.h"
 %}
 
 %include "lsst/p_lsstSwig.i"
 %initializeNumPy(meas_astrom)
-
+%{
+#include "ndarray/swig.h"
+#include "ndarray/swig/eigen.h"
+%}
+%include "ndarray.i"
 %include "lsst/pex/config.h"
 
 %shared_ptr(lsst::meas::astrom::MatchOptimisticBControl);
@@ -28,8 +36,35 @@ Python interface to lsst::meas::astrom
 %import "lsst/afw/table/tableLib.i"
 %import "lsst/afw/image/wcs.i"
 %import "lsst/afw/math/statistics.i"
+%import "lsst/afw/geom/geomLib.i"
 
 %include "lsst/meas/astrom/matchOptimisticB.h"
+
+%include "std_pair.i"
+
+namespace std { // have to do this in namespace block so Swig can find size_t
+%template(DoubleSizePair) pair<double,size_t>;
+}
+
+%declareNumPyConverters(ndarray::Array<double const,2,2>)
+
+// Avoid dangling references by returning by value in Python.
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransform::getPoly)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransform::getInputScaling)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransform::getOutputScalingInverse)
+%include "lsst/meas/astrom/PolynomialTransform.h"
+
+%returnCopy(lsst::meas::astrom::SipTransformBase::getPoly)
+%returnCopy(lsst::meas::astrom::SipTransformBase::getPixelOrigin)
+%returnCopy(lsst::meas::astrom::SipTransformBase::getCDMatrix)
+%include "lsst/meas/astrom/SipTransform.h"
+
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getPoly)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getInputScaling)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getOutputScaling)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getTransform)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getData)
+%include "lsst/meas/astrom/ScaledPolynomialTransformFitter.h"
 
 %include "lsst/meas/astrom/makeMatchStatistics.h"
 

--- a/python/lsst/meas/astrom/astromLib.i
+++ b/python/lsst/meas/astrom/astromLib.i
@@ -25,8 +25,8 @@ Python interface to lsst::meas::astrom
 %include "lsst/p_lsstSwig.i"
 %initializeNumPy(meas_astrom)
 %{
-#include "ndarray/swig.h"
-#include "ndarray/swig/eigen.h"
+#include "ndarray/converter.h"
+#include "ndarray/converter/eigen.h"
 %}
 %include "ndarray.i"
 %include "lsst/pex/config.h"

--- a/python/lsst/meas/astrom/astromLib.i
+++ b/python/lsst/meas/astrom/astromLib.i
@@ -38,33 +38,9 @@ Python interface to lsst::meas::astrom
 %import "lsst/afw/math/statistics.i"
 %import "lsst/afw/geom/geomLib.i"
 
+%include "lsst/meas/astrom/transforms.i"
+
 %include "lsst/meas/astrom/matchOptimisticB.h"
-
-%include "std_pair.i"
-
-namespace std { // have to do this in namespace block so Swig can find size_t
-%template(DoubleSizePair) pair<double,size_t>;
-}
-
-%declareNumPyConverters(ndarray::Array<double const,2,2>)
-
-// Avoid dangling references by returning by value in Python.
-%returnCopy(lsst::meas::astrom::ScaledPolynomialTransform::getPoly)
-%returnCopy(lsst::meas::astrom::ScaledPolynomialTransform::getInputScaling)
-%returnCopy(lsst::meas::astrom::ScaledPolynomialTransform::getOutputScalingInverse)
-%include "lsst/meas/astrom/PolynomialTransform.h"
-
-%returnCopy(lsst::meas::astrom::SipTransformBase::getPoly)
-%returnCopy(lsst::meas::astrom::SipTransformBase::getPixelOrigin)
-%returnCopy(lsst::meas::astrom::SipTransformBase::getCDMatrix)
-%include "lsst/meas/astrom/SipTransform.h"
-
-%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getPoly)
-%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getInputScaling)
-%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getOutputScaling)
-%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getTransform)
-%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getData)
-%include "lsst/meas/astrom/ScaledPolynomialTransformFitter.h"
 
 %include "lsst/meas/astrom/makeMatchStatistics.h"
 

--- a/python/lsst/meas/astrom/astrometry.py
+++ b/python/lsst/meas/astrom/astrometry.py
@@ -446,6 +446,7 @@ class AstrometryTask(pipeBase.Task):
             bbox=bbox,
             refCat=refCat,
             sourceCat=sourceCat,
+            exposure=exposure,
         )
         fitWcs = fitRes.wcs
         scatterOnSky = fitRes.scatterOnSky

--- a/python/lsst/meas/astrom/fitSipDistortion.py
+++ b/python/lsst/meas/astrom/fitSipDistortion.py
@@ -1,0 +1,428 @@
+from __future__ import absolute_import, division, print_function
+from builtins import range
+
+import lsst.pipe.base
+import lsst.afw.image
+import lsst.afw.geom
+import lsst.afw.coord
+import lsst.afw.display
+from .astromLib import (
+    ScaledPolynomialTransformFitter,
+    OutlierRejectionControl,
+    SipForwardTransform,
+    SipReverseTransform,
+    makeMatchStatisticsInRadians,
+    makeWcs
+)
+
+from .setMatchDistance import setMatchDistance
+
+__all__ = ["FitSipDistortionTask", "FitSipDistortionConfig"]
+
+
+class FitSipDistortionConfig(lsst.pex.config.Config):
+    order = lsst.pex.config.RangeField(
+        doc="Order of SIP polynomial",
+        dtype=int,
+        default=4,
+        min=0,
+    )
+    numRejIter = lsst.pex.config.RangeField(
+        doc="Number of rejection iterations",
+        dtype=int,
+        default=3,
+        min=0,
+    )
+    rejSigma = lsst.pex.config.RangeField(
+        doc="Number of standard deviations for clipping level",
+        dtype=float,
+        default=3.0,
+        min=0.0,
+    )
+    nClipMin = lsst.pex.config.Field(
+        doc="Minimum number of matches to reject when sigma-clipping",
+        dtype=int,
+        default=0
+    )
+    nClipMax = lsst.pex.config.Field(
+        doc="Maximum number of matches to reject when sigma-clipping",
+        dtype=int,
+        default=1
+    )
+    maxScatterArcsec = lsst.pex.config.RangeField(
+        doc="Maximum median scatter of a WCS fit beyond which the fit fails (arcsec); " +
+            "be generous, as this is only intended to catch catastrophic failures",
+        dtype=float,
+        default=10,
+        min=0,
+    )
+    refUncertainty = lsst.pex.config.Field(
+        doc="RMS uncertainty in reference catalog positions, in pixels.  Will be added " +
+            "in quadrature with measured uncertainties in the fit.",
+        dtype=float,
+        default=0.25,
+    )
+    nGridX = lsst.pex.config.Field(
+        doc="Number of X grid points used to invert the SIP reverse transform.",
+        dtype=int,
+        default=100,
+    )
+    nGridY = lsst.pex.config.Field(
+        doc="Number of Y grid points used to invert the SIP reverse transform.",
+        dtype=int,
+        default=100,
+    )
+    gridBorder = lsst.pex.config.Field(
+        doc="When setting the gird region, how much to extend the image " +
+            "bounding box (in pixels) before transforming it to intermediate " +
+            "world coordinates using the initial WCS.",
+        dtype=float,
+        default=50.0,
+    )
+
+
+class FitSipDistortionTask(lsst.pipe.base.Task):
+    """Fit a TAN-SIP WCS given a list of reference object/source matches
+
+    FitSipDistortionTask is a drop-in replacement for
+    :py:class:`lsst.meas.astrom.FitTanSinWcsTask`.  It is built on fundamentally
+    stronger fitting algorithms, but has received significantly less testing.
+
+    Like :py:class:`lsst.meas.astrom.FitTanSinWcsTask`, this task is most
+    easily used as the wcsFitter component of
+    :py:class:`lsst.meas.astrom.AstrometryTask`; it can be enabled in a config
+    file via e.g.
+
+    .. code-block:: py
+
+       from lsst.meas.astrom import FitSipDistortionTask
+       config.(...).astometry.wcsFitter.retarget(FitSipDistortionTask)
+
+    Algorithm
+    ---------
+
+    The algorithm used by FitSipDistortionTask involves three steps:
+
+     - We set the CRVAL and CRPIX reference points to the mean positions of
+       the matches, while holding the CD matrix fixed to the value passed in
+       to the run() method.  This work is done by the makeInitialWcs method.
+
+     - We fit the SIP "reverse transform" (the AP and BP polynomials that map
+       "intermediate world coordinates" to pixels).  This happens iteratively;
+       while fitting for the polynomial coefficients given a set of matches is
+       a linear operation that can be done without iteration, outlier
+       rejection using sigma-clipping and estimation of the intrinsic scatter
+       are not. By fitting the reverse transform first, we can do outlier
+       rejection in pixel coordinates, where we can better handle the source
+       measurement uncertainties that contribute to the overall scatter.  This
+       fit results in a
+       :cpp:class:`lsst::meas::astrom::ScaledPolynomialTransform`, which is
+       somewhat more general than the SIP reverse transform in that it allows
+       an affine transform both before and after the polynomial.  This is
+       somewhat more numerically stable than the SIP form, which applies only
+       a linear transform (with no offset) before the polynomial and only a
+       shift afterwards.  We only convert to SIP form once the fitting is
+       complete.  This conversion is exact (though it may be subject to
+       significant round-off error) as long as we do not attempt to null the
+       low-order SIP polynomial terms (we do not).
+
+     - Once the SIP reverse transform has been fit, we use it to populate a
+       grid of points that we use as the data points for fitting its inverse,
+       the SIP forward transform.  Because our "data" here is artificial,
+       there is no need for outlier rejection or uncertainty handling.  We
+       again fit a general scaled polynomial, and only convert to SIP form
+       when the fit is complete.
+
+
+    Debugging
+    ---------
+
+    Enabling DEBUG-level logging on this task will report the number of
+    outliers rejected and the current estimate of intrinsic scatter at each
+    iteration.
+
+    FitSipDistortionTask also supports a single lsstDebug display variable,
+    FitSipDistortionTask.display.  If this evaluates to True, an image display
+    overlaid with the positions of sources and reference objects will be shown
+    for every iteration in the reverse transform fit.  The legend for the
+    overlay is:
+
+    Red X
+        Reference sources transformed without SIP distortion terms; this
+        uses a TAN WCS whose CRPIX, CRVAL and CD matrix are the same
+        as those in the TAN-SIP WCS being fit.  These are not expected to
+        line up with sources unless distortion is small.
+
+    Magenta X
+        Same as Red X, but for matches that were rejected as outliers.
+
+    Red O
+        Reference sources using the current best-fit TAN-SIP WCS.  These
+        are connected to the corresponding non-distorted WCS position by
+        a red line, and should be a much better fit to source positions
+        than the Red Xs.
+
+    Magenta O
+        Same as Red O, but for matches that were rejected as outliers.
+
+    Green Ellipse
+        Source positions and their error ellipses, including the current
+        estimate of the intrinsic scatter.
+
+    Cyan Ellipse
+        Same as Green Ellipse, but for matches that were rejected as outliers.
+
+
+    Parameters
+    ----------
+    See :py:class:`lsst.pipe.base.Task`; FitSipDistortionTask does not add any
+    additional constructor parameters.
+
+    """
+
+    ConfigClass = FitSipDistortionConfig
+    _DefaultName = "fitWcs"
+
+    def __init__(self, **kwds):
+        lsst.pipe.base.Task.__init__(self, **kwds)
+        self.outlierRejectionCtrl = OutlierRejectionControl()
+        self.outlierRejectionCtrl.nClipMin = self.config.nClipMin
+        self.outlierRejectionCtrl.nClipMax = self.config.nClipMax
+        self.outlierRejectionCtrl.nSigma = self.config.rejSigma
+
+    @lsst.pipe.base.timeMethod
+    def fitWcs(self, matches, initWcs, bbox=None, refCat=None, sourceCat=None, exposure=None):
+        """Fit a TAN-SIP WCS from a list of reference object/source matches
+
+        Parameters
+        ----------
+
+        matches : :cpp:class:`lsst::afw::table::ReferenceMatchVector`
+            A sequence of reference object/source matches.
+            The following fields are read:
+            - match.first (reference object) coord
+            - match.second (source) centroid
+            The following fields are written:
+            - match.first (reference object) centroid,
+            - match.second (source) centroid
+            - match.distance (on sky separation, in radians)
+        initWcs : :cpp:class:`lsst::afw::image::Wcs`
+            An initial WCS whose CD matrix is used as the final CD matrix.
+        bbox : :cpp:class:`lsst::afw::geom::Box2I`
+            The region over which the WCS will be valid (PARENT pixel coordinates);
+            if None or an empty box then computed from matches
+        refCat : :cpp:class:`lsst::afw::table::SimpleCatalog`
+            Reference object catalog, or None.
+            If provided then all centroids are updated with the new WCS,
+            otherwise only the centroids for ref objects in matches are updated.
+            Required fields are "centroid_x", "centroid_y", "coord_ra", and "coord_dec".
+        sourceCat : :cpp:class:`lsst::afw::table::SourceCatalog`
+            Source catalog, or None.
+            If provided then coords are updated with the new WCS;
+            otherwise only the coords for sources in matches are updated.
+            Required input fields are "slot_Centroid_x", "slot_Centroid_y",
+            "slot_Centroid_xSigma", "slot_Centroid_ySigma", and optionally
+            "slot_Centroid_x_y_Cov".  The "coord_ra" and "coord_dec" fields
+            will be updated but are not used as input.
+        exposure : :cpp:class:`lsst::afw::image::Exposure`
+            An Exposure or other displayable image on which matches can be
+            overplotted.  Ignored (and may be None) if display-based debugging
+            is not enabled via lsstDebug.
+
+        Returns
+        -------
+
+        An lsst.pipe.base.Struct with the following fields:
+
+        wcs : :cpp:class:`lsst::afw::image::TanWcs`
+            The best-fit WCS.
+        scatterOnSky : :cpp:class:`lsst::afw::geom::Angle`
+            The median on-sky separation between reference objects and
+            sources in "matches", as an lsst.afw.geom.Angle
+        """
+        import lsstDebug
+        display = lsstDebug.Info(__name__).display
+
+        if bbox is None:
+            bbox = lsst.afw.geom.Box2D()
+            for match in matches:
+                bbox.include(match.second.getCentroid())
+            bbox = lsst.afw.geom.Box2I(bbox)
+
+        wcs = self.makeInitialWcs(matches, initWcs)
+        cdMatrix = lsst.afw.geom.LinearTransform(wcs.getCDMatrix())
+
+        # Fit the "reverse" mapping from intermediate world coordinates to
+        # pixels, rejecting outliers. Fitting in this direction first makes it
+        # easier to handle the case where we have uncertainty on source
+        # positions but not reference positions.  That's the case we have
+        # right now for purely bookeeeping reasons, and it may be the case we
+        # have in the future when we us Gaia as the reference catalog.
+        revFitter = ScaledPolynomialTransformFitter.fromMatches(self.config.order, matches, wcs,
+                                                                self.config.refUncertainty)
+        revFitter.fit()
+        for nIter in range(self.config.numRejIter):
+            revFitter.updateModel()
+            intrinsicScatter = revFitter.updateIntrinsicScatter()
+            clippedSigma, nRejected = revFitter.rejectOutliers(self.outlierRejectionCtrl)
+            self.log.debug(
+                "Iteration {0}: intrinsic scatter is {1:4.3f} pixels, "
+                "rejected {2} outliers at {3:3.2f} sigma.".format(
+                    nIter+1, intrinsicScatter, nRejected, clippedSigma
+                )
+            )
+            if display:
+                self.display(revFitter, exposure=exposure, bbox=bbox)
+            revFitter.fit()
+        revScaledPoly = revFitter.getTransform()
+        # Convert the generic ScaledPolynomialTransform result to SIP form
+        # with given CRPIX and CD (this is an exact conversion, up to
+        # floating-point round-off error)
+        sipReverse = SipReverseTransform.convert(revScaledPoly, wcs.getPixelOrigin(), cdMatrix)
+
+        # Fit the forward mapping to a grid of points created from the reverse
+        # transform.  Because that grid needs to be defined in intermediate
+        # world coordinates, and we don't have a good way to get from pixels to
+        # intermediate world coordinates yet (that's what we're fitting), we'll
+        # first grow the box to make it conservatively large...
+        gridBBoxPix = lsst.afw.geom.Box2D(bbox)
+        gridBBoxPix.grow(self.config.gridBorder)
+        # ...and then we'll transform using just the CRPIX offset and CD matrix
+        # linear transform, which is the TAN-only (no SIP distortion, and
+        # hence approximate) mapping from pixels to intermediate world
+        # coordinates.
+        gridBBoxIwc = lsst.afw.geom.Box2D()
+        for point in gridBBoxPix.getCorners():
+            point -= lsst.afw.geom.Extent2D(wcs.getPixelOrigin())
+            gridBBoxIwc.include(cdMatrix(point))
+        fwdFitter = ScaledPolynomialTransformFitter.fromGrid(self.config.order, gridBBoxIwc,
+                                                             self.config.nGridX, self.config.nGridY,
+                                                             revScaledPoly)
+        fwdFitter.fit()
+        # Convert to SIP forward form.
+        fwdScaledPoly = fwdFitter.getTransform()
+        sipForward = SipForwardTransform.convert(fwdScaledPoly, wcs.getPixelOrigin(), cdMatrix)
+
+        # Make a new WCS from the SIP transform objects and the CRVAL in the
+        # initial WCS.
+        wcs = makeWcs(sipForward, sipReverse, wcs.getSkyOrigin())
+
+        if refCat is not None:
+            self.log.debug("Updating centroids in refCat")
+            lsst.afw.table.updateRefCentroids(wcs, refList=refCat)
+        else:
+            self.log.warn("Updating reference object centroids in match list; refCat is None")
+            lsst.afw.table.updateRefCentroids(wcs, refList=[match.first for match in matches])
+
+        if sourceCat is not None:
+            self.log.debug("Updating coords in sourceCat")
+            lsst.afw.table.updateSourceCoords(wcs, sourceList=sourceCat)
+        else:
+            self.log.warn("Updating source coords in match list; sourceCat is None")
+            lsst.afw.table.updateSourceCoords(wcs, sourceList=[match.second for match in matches])
+
+        self.log.debug("Updating distance in match list")
+        setMatchDistance(matches)
+
+        stats = makeMatchStatisticsInRadians(wcs, matches, lsst.afw.math.MEDIAN)
+        scatterOnSky = stats.getValue()*lsst.afw.geom.radians
+
+        if scatterOnSky.asArcseconds() > self.config.maxScatterArcsec:
+            raise lsst.pipe.base.TaskError(
+                "Fit failed: median scatter on sky = %0.3f arcsec > %0.3f config.maxScatterArcsec" %
+                (scatterOnSky.asArcseconds(), self.config.maxScatterArcsec))
+
+        return lsst.pipe.base.Struct(
+            wcs=wcs,
+            scatterOnSky=scatterOnSky,
+        )
+
+    def display(self, revFitter, exposure=None, bbox=None):
+        """Display positions and outlier status overlaid on an image.
+
+        This method is called by fitWcs when display debugging is enabled.  It
+        always drops into pdb before returning to allow interactive inspection,
+        and hence it should never be called in non-interactive contexts.
+
+        Parameters
+        ----------
+
+        revFitter : :cpp:class:`lsst::meas::astrom::ScaledPolynomialTransformFitter`
+            Fitter object initialized with `fromMatches` for fitting a "reverse"
+            distortion: the mapping from intermediate world coordinates to
+            pixels.
+        exposure : :cpp:class:`lsst::afw::image::Exposure`
+            An Exposure or other displayable image on which matches can be
+            overplotted.
+        bbox : :cpp:class:`lsst::afw::geom::Box2I`
+            Bounding box of the region on which matches should be plotted.
+        """
+
+        data = revFitter.getData()
+        disp = lsst.afw.display.getDisplay()
+        if exposure is not None:
+            disp.mtv(exposure)
+        elif bbox is not None:
+            disp.mtv(exposure=lsst.afw.image.ExposureF(bbox))
+        else:
+            raise TypeError("At least one of 'exposure' and 'bbox' must be provided.")
+        data = revFitter.getData()
+        srcKey = lsst.afw.table.Point2DKey(data.schema["src"])
+        srcErrKey = lsst.afw.table.CovarianceMatrix2fKey(data.schema["src"], ["x", "y"])
+        refKey = lsst.afw.table.Point2DKey(data.schema["initial"])
+        modelKey = lsst.afw.table.Point2DKey(data.schema["model"])
+        rejectedKey = data.schema.find("rejected").key
+        with disp.Buffering():
+            for record in data:
+                colors = ((lsst.afw.display.RED, lsst.afw.display.GREEN)
+                          if not record.get(rejectedKey) else
+                          (lsst.afw.display.MAGENTA, lsst.afw.display.CYAN))
+                rx, ry = record.get(refKey)
+                disp.dot("x", rx, ry, size=10, ctype=colors[0])
+                mx, my = record.get(modelKey)
+                disp.dot("o", mx, my, size=10, ctype=colors[0])
+                disp.line([(rx, ry), (mx, my)], ctype=colors[0])
+                sx, sy = record.get(srcKey)
+                sErr = record.get(srcErrKey)
+                sEllipse = lsst.afw.geom.ellipses.Quadrupole(sErr[0, 0], sErr[1, 1], sErr[0, 1])
+                disp.dot(sEllipse, sx, sy, ctype=colors[1])
+        print("Dropping into debugger to allow inspection of display. Type 'continue' when done.")
+        import pdb
+        pdb.set_trace()
+
+    def makeInitialWcs(self, matches, wcs):
+        """Generate a guess Wcs from the astrometric matches
+
+        We create a Wcs anchored at the center of the matches, with the scale
+        of the input Wcs.  This is necessary because the Wcs may have a very
+        approximation position (as is common with telescoped-generated Wcs).
+        We're using the best of each: positions from the matches, and scale
+        from the input Wcs.
+
+        Parameters
+        ----------
+        matches : :cpp:class:`lsst::afw::table::ReferenceMatchVector`
+            A sequence of reference object/source matches.
+            The following fields are read:
+            - match.first (reference object) coord
+            - match.second (source) centroid
+        wcs : :cpp:class:`lsst::afw::image::Wcs`
+            An initial WCS whose CD matrix is used as the CD matrix of the
+            result.
+
+        Returns
+        -------
+
+        A new :cpp:class:`lsst::afw::image::Wcs`.
+        """
+        crpix = lsst.afw.geom.Extent2D(0, 0)
+        crval = lsst.afw.geom.Extent3D(0, 0, 0)
+        for mm in matches:
+            crpix += lsst.afw.geom.Extent2D(mm.second.getCentroid())
+            crval += lsst.afw.geom.Extent3D(mm.first.getCoord().toIcrs().getVector())
+        crpix /= len(matches)
+        crval /= len(matches)
+        cd = wcs.getCDMatrix()
+        newWcs = lsst.afw.image.makeWcs(lsst.afw.coord.IcrsCoord(lsst.afw.geom.Point3D(crval)),
+                                        lsst.afw.geom.Point2D(crpix), cd[0, 0], cd[0, 1], cd[1, 0], cd[1, 1])
+        return newWcs

--- a/python/lsst/meas/astrom/fitTanSipWcs.py
+++ b/python/lsst/meas/astrom/fitTanSipWcs.py
@@ -104,7 +104,7 @@ class FitTanSipWcsTask(pipeBase.Task):
     _DefaultName = "fitWcs"
 
     @pipeBase.timeMethod
-    def fitWcs(self, matches, initWcs, bbox=None, refCat=None, sourceCat=None):
+    def fitWcs(self, matches, initWcs, bbox=None, refCat=None, sourceCat=None, exposure=None):
         """!Fit a TAN-SIP WCS from a list of reference object/source matches
 
         @param[in,out] matches  a list of reference object/source matches
@@ -127,6 +127,7 @@ class FitTanSipWcsTask(pipeBase.Task):
             If provided then coords are updated with the new WCS;
             otherwise only the coords for sources in matches are updated.
             Required fields are "slot_Centroid_x", "slot_Centroid_y", and "coord_ra", and "coord_dec".
+        @param[in] exposure  Ignored; present for consistency with FitSipDistortionTask.
 
         @return an lsst.pipe.base.Struct with the following fields:
         - wcs  the fit WCS as an lsst.afw.image.Wcs

--- a/python/lsst/meas/astrom/fitTanSipWcs.py
+++ b/python/lsst/meas/astrom/fitTanSipWcs.py
@@ -148,6 +148,12 @@ class FitTanSipWcsTask(pipeBase.Task):
             rejected = self.rejectMatches(matches, wcs, rejected)
             if rejected.sum() == len(rejected):
                 raise RuntimeError("All matches rejected in iteration %d" % (rej + 1,))
+            self.log.debug(
+                "Iteration {0} of astrometry fitting: rejected {1} outliers, "
+                "out of {2} total matches.".format(
+                    rej, rejected.sum(), len(rejected)
+                )
+            )
             if debug.plot:
                 print("Plotting fit after rejection iteration %d/%d" % (rej + 1, self.config.numRejIter))
                 self.plotFit(matches, wcs, rejected)

--- a/python/lsst/meas/astrom/transforms.i
+++ b/python/lsst/meas/astrom/transforms.i
@@ -1,0 +1,41 @@
+// -*- lsst-c++ -*-
+
+%{
+#include "lsst/afw/table.h"
+#include "lsst/afw/image/Wcs.h"
+#include "lsst/afw/image/TanWcs.h"
+#include "lsst/meas/astrom/PolynomialTransform.h"
+#include "lsst/meas/astrom/SipTransform.h"
+#include "lsst/meas/astrom/ScaledPolynomialTransformFitter.h"
+%}
+
+%include "std_pair.i"
+
+%import "lsst/afw/table/tableLib.i"
+%import "lsst/afw/image/wcs.i"
+%import "lsst/afw/geom/geomLib.i"
+
+
+namespace std { // have to do this in namespace block so Swig can find size_t
+%template(DoubleSizePair) pair<double,size_t>;
+}
+
+%declareNumPyConverters(ndarray::Array<double const,2,2>)
+
+// Avoid dangling references by returning by value in Python.
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransform::getPoly)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransform::getInputScaling)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransform::getOutputScalingInverse)
+%include "lsst/meas/astrom/PolynomialTransform.h"
+
+%returnCopy(lsst::meas::astrom::SipTransformBase::getPoly)
+%returnCopy(lsst::meas::astrom::SipTransformBase::getPixelOrigin)
+%returnCopy(lsst::meas::astrom::SipTransformBase::getCDMatrix)
+%include "lsst/meas/astrom/SipTransform.h"
+
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getPoly)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getInputScaling)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getOutputScaling)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getTransform)
+%returnCopy(lsst::meas::astrom::ScaledPolynomialTransformFitter::getData)
+%include "lsst/meas/astrom/ScaledPolynomialTransformFitter.h"

--- a/src/PolynomialTransform.cc
+++ b/src/PolynomialTransform.cc
@@ -1,0 +1,301 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * Copyright 2016 LSST/AURA
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#include "lsst/meas/astrom/PolynomialTransform.h"
+#include "lsst/meas/astrom/SipTransform.h"
+#include "lsst/meas/astrom/detail/polynomialUtils.h"
+
+namespace lsst { namespace meas { namespace astrom {
+
+PolynomialTransform PolynomialTransform::convert(ScaledPolynomialTransform const & scaled) {
+    return compose(
+        scaled.getOutputScalingInverse(),
+        compose(scaled.getPoly(), scaled.getInputScaling())
+    );
+}
+
+PolynomialTransform PolynomialTransform::convert(SipForwardTransform const & other) {
+    PolynomialTransform poly = other.getPoly();
+    // Adding 1 here accounts for the extra terms outside the sum in the SIP
+    // transform definition (see SipForwardTransform docs) - note that you can
+    // fold those terms into the sum by adding 1 from the A_10 and B_01 terms.
+    poly._xCoeffs(1, 0) += 1;
+    poly._yCoeffs(0, 1) += 1;
+    return compose(
+        other.getCDMatrix(),
+        compose(
+            poly,
+            afw::geom::AffineTransform(afw::geom::Point2D() - other.getPixelOrigin())
+        )
+    );
+}
+
+PolynomialTransform PolynomialTransform::convert(SipReverseTransform const & other) {
+    PolynomialTransform poly = other.getPoly();
+    // Account for the terms outside the sum in the SIP definition (see comment
+    // earlier in the file for more explanation).
+    poly._xCoeffs(1, 0) += 1;
+    poly._yCoeffs(0, 1) += 1;
+    return compose(
+        afw::geom::AffineTransform(afw::geom::Extent2D(other.getPixelOrigin())),
+        compose(
+            poly,
+            other._cdInverse
+        )
+    );
+}
+
+PolynomialTransform::PolynomialTransform(int order) :
+    _xCoeffs(),
+    _yCoeffs(),
+    _u(),
+    _v()
+{
+    if (order < 0) {
+        throw LSST_EXCEPT(
+            pex::exceptions::LengthError,
+            "PolynomialTransform order must be >= 0"
+        );
+    }
+    // Delay allocation until after error checking.
+    _xCoeffs.reset(ndarray::Array<double,2,2>(ndarray::allocate(order + 1, order + 1)));
+    _yCoeffs.reset(ndarray::Array<double,2,2>(ndarray::allocate(order + 1, order + 1)));
+    _xCoeffs.setZero();
+    _yCoeffs.setZero();
+    _u = Eigen::VectorXd(order + 1);
+    _v = Eigen::VectorXd(order + 1);
+}
+
+PolynomialTransform::PolynomialTransform(
+    ndarray::Array<double const,2,2> const & xCoeffs,
+    ndarray::Array<double const,2,2> const & yCoeffs
+) : _xCoeffs(ndarray::copy(xCoeffs)),
+    _yCoeffs(ndarray::copy(yCoeffs)),
+    _u(_xCoeffs.rows()),
+    _v(_xCoeffs.rows())
+{
+    if (xCoeffs.getShape() != yCoeffs.getShape()) {
+        throw LSST_EXCEPT(
+            pex::exceptions::LengthError,
+            (boost::format(
+                "X and Y coefficient matrices must have the same shape: "
+                " (%d,%d) != (%d,%d)"
+                ) % xCoeffs.getSize<0>() % xCoeffs.getSize<1>()
+                  % yCoeffs.getSize<0>() % yCoeffs.getSize<1>()
+            ).str()
+        );
+    }
+    if (_xCoeffs.cols() != _xCoeffs.rows()) {
+        throw LSST_EXCEPT(
+            pex::exceptions::LengthError,
+            (boost::format(
+                "Coefficient matrices must be triangular, not trapezoidal: "
+                " %d != %d "
+                ) % _xCoeffs.rows() % _xCoeffs.cols()
+            ).str()
+        );
+    }
+}
+
+PolynomialTransform::PolynomialTransform(PolynomialTransform const & other) :
+    _xCoeffs(ndarray::copy(other.getXCoeffs())),
+    _yCoeffs(ndarray::copy(other.getYCoeffs())),
+    _u(other._u.size()),
+    _v(other._v.size())
+{}
+
+PolynomialTransform::PolynomialTransform(PolynomialTransform && other) :
+    _xCoeffs(),
+    _yCoeffs(),
+    _u(),
+    _v()
+{
+    this->swap(other);
+}
+
+PolynomialTransform & PolynomialTransform::operator=(PolynomialTransform const & other) {
+    if (&other != this) {
+        PolynomialTransform tmp(other);
+        tmp.swap(*this);
+    }
+    return *this;
+}
+
+PolynomialTransform & PolynomialTransform::operator=(PolynomialTransform && other) {
+    if (&other != this) {
+        other.swap(*this);
+    }
+    return *this;
+}
+
+void PolynomialTransform::swap(PolynomialTransform & other) {
+    _xCoeffs.swap(other._xCoeffs);
+    _yCoeffs.swap(other._yCoeffs);
+    _u.swap(other._u);
+    _v.swap(other._v);
+}
+
+afw::geom::AffineTransform PolynomialTransform::linearize(afw::geom::Point2D const & in) const {
+    double xu = 0.0, xv = 0.0, yu = 0.0, yv = 0.0, x = 0.0, y = 0.0;
+    int const order = getOrder();
+    detail::computePowers(_u, in.getX());
+    detail::computePowers(_v, in.getY());
+    for (int p = 0; p <= order; ++p) {
+        for (int q = 0; q <= order; ++q) {
+            if (p > 0) {
+                xu += _xCoeffs(p, q) * p * _u[p - 1] * _v[q];
+                yu += _yCoeffs(p, q) * p * _u[p - 1] * _v[q];
+            }
+            if (q > 0) {
+                xv += _xCoeffs(p, q) * q * _u[p] * _v[q - 1];
+                yv += _yCoeffs(p, q) * q * _u[p] * _v[q - 1];
+            }
+            x += _xCoeffs(p, q) * _u[p] * _v[q];
+            y += _yCoeffs(p, q) * _u[p] * _v[q];
+        }
+    }
+    afw::geom::LinearTransform linear;
+    linear.getMatrix()(0, 0) = xu;
+    linear.getMatrix()(0, 1) = xv;
+    linear.getMatrix()(1, 0) = yu;
+    linear.getMatrix()(1, 1) = yv;
+    afw::geom::Point2D origin(x, y);
+    return afw::geom::AffineTransform(linear, origin - linear(in));
+}
+
+afw::geom::Point2D PolynomialTransform::operator()(afw::geom::Point2D const & in) const {
+    int const order = getOrder();
+    detail::computePowers(_u, in.getX());
+    detail::computePowers(_v, in.getY());
+    double x = 0;
+    double y = 0;
+    for (int p = 0; p <= order; ++p) {
+        for (int q = 0; q <= order; ++q) {
+            x += _xCoeffs(p, q) * _u[p] * _v[q];
+            y += _yCoeffs(p, q) * _u[p] * _v[q];
+        }
+    }
+    return afw::geom::Point2D(x, y);
+}
+
+ScaledPolynomialTransform ScaledPolynomialTransform::convert(PolynomialTransform const & poly) {
+    return ScaledPolynomialTransform(poly, afw::geom::AffineTransform(), afw::geom::AffineTransform());
+}
+
+ScaledPolynomialTransform ScaledPolynomialTransform::convert(SipForwardTransform const & sipForward) {
+    ScaledPolynomialTransform result(
+        sipForward.getPoly(),
+        afw::geom::AffineTransform(afw::geom::Point2D(0, 0) - sipForward.getPixelOrigin()),
+        afw::geom::AffineTransform(sipForward.getCDMatrix())
+    );
+    // Account for the terms outside the sum in the SIP definition (see comment
+    // earlier in the file for more explanation).
+    result._poly._xCoeffs(1, 0) += 1;
+    result._poly._yCoeffs(0, 1) += 1;
+    return result;
+}
+
+ScaledPolynomialTransform ScaledPolynomialTransform::convert(SipReverseTransform const & sipReverse) {
+    ScaledPolynomialTransform result(
+        sipReverse.getPoly(),
+        afw::geom::AffineTransform(sipReverse._cdInverse),
+        afw::geom::AffineTransform(afw::geom::Extent2D(sipReverse.getPixelOrigin()))
+    );
+    result._poly._xCoeffs(1, 0) += 1;
+    result._poly._yCoeffs(0, 1) += 1;
+    return result;
+}
+
+ScaledPolynomialTransform::ScaledPolynomialTransform(
+    PolynomialTransform const & poly,
+    afw::geom::AffineTransform const & inputScaling,
+    afw::geom::AffineTransform const & outputScalingInverse
+) :
+    _poly(poly),
+    _inputScaling(inputScaling),
+    _outputScalingInverse(outputScalingInverse)
+{}
+
+void ScaledPolynomialTransform::swap(ScaledPolynomialTransform & other) {
+    _poly.swap(other._poly);
+    std::swap(_inputScaling, other._inputScaling);
+    std::swap(_outputScalingInverse, other._outputScalingInverse);
+}
+
+afw::geom::AffineTransform ScaledPolynomialTransform::linearize(afw::geom::Point2D const & in) const {
+    return _outputScalingInverse*_poly.linearize(_inputScaling(in))*_inputScaling;
+}
+
+afw::geom::Point2D ScaledPolynomialTransform::operator()(afw::geom::Point2D const & in) const {
+    return _outputScalingInverse(_poly(_inputScaling(in)));
+}
+
+PolynomialTransform compose(afw::geom::AffineTransform const & t1, PolynomialTransform const & t2) {
+    typedef afw::geom::AffineTransform AT;
+    PolynomialTransform result(t2.getOrder());
+    result._xCoeffs = t2._xCoeffs*t1[AT::XX] + t2._yCoeffs*t1[AT::XY];
+    result._yCoeffs = t2._xCoeffs*t1[AT::YX] + t2._yCoeffs*t1[AT::YY];
+    result._xCoeffs(0, 0) += t1[AT::X];
+    result._yCoeffs(0, 0) += t1[AT::Y];
+    return result;
+}
+
+PolynomialTransform compose(PolynomialTransform const & t1, afw::geom::AffineTransform const & t2) {
+    typedef afw::geom::AffineTransform AT;
+    int const order = t1.getOrder();
+    if (order < 1) {
+        PolynomialTransform t1a(1);
+        t1a._xCoeffs(0, 0) = t1._xCoeffs(0, 0);
+        t1a._yCoeffs(0, 0) = t1._yCoeffs(0, 0);
+        return compose(t1a, t2);
+    }
+    detail::BinomialMatrix binomial(order);
+    // For each of these, (e.g.) a[n] == pow(a, n)
+    auto const t2u = detail::computePowers(t2[AT::X], order);
+    auto const t2v = detail::computePowers(t2[AT::Y], order);
+    auto const t2uu = detail::computePowers(t2[AT::XX], order);
+    auto const t2uv = detail::computePowers(t2[AT::XY], order);
+    auto const t2vu = detail::computePowers(t2[AT::YX], order);
+    auto const t2vv = detail::computePowers(t2[AT::YY], order);
+    PolynomialTransform result(order);
+    for (int p = 0; p <= order; ++p) {
+        for (int m = 0; m <= p; ++m) {
+            for (int j = 0; j <= m; ++j) {
+                for (int q = 0; p + q <= order; ++q) {
+                    for (int n = 0; n <= q; ++n) {
+                        for (int k = 0; k <= n; ++k) {
+                            double z = binomial(p,m) * t2u[p-m] * binomial(m,j) * t2uu[j] * t2uv[m-j] *
+                                       binomial(q,n) * t2v[q-n] * binomial(n,k) * t2vu[k] * t2vv[n-k];
+                            result._xCoeffs(j + k, m + n - j - k) += t1._xCoeffs(p, q) * z;
+                            result._yCoeffs(j + k, m + n - j - k) += t1._yCoeffs(p, q) * z;
+                        } // k
+                    } // n
+                } // q
+            } // j
+        } // m
+    } // p
+    return result;
+}
+
+}}} // namespace lsst::meas::astrom

--- a/src/ScaledPolynomialTransformFitter.cc
+++ b/src/ScaledPolynomialTransformFitter.cc
@@ -1,0 +1,481 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * Copyright 2016 LSST/AURA
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#include <map>
+
+#include "Eigen/LU" // for determinant, even though it's a 2x2 that doesn't use actual LU implementation
+
+#include "boost/math/tools/minima.hpp"
+
+#include "lsst/meas/astrom/ScaledPolynomialTransformFitter.h"
+#include "lsst/meas/astrom/detail/polynomialUtils.h"
+#include "lsst/afw/table/aggregates.h"
+#include "lsst/afw/table/Match.h"
+#include "lsst/afw/math/LeastSquares.h"
+
+// When developing this code, it was used to add an in-line check for the
+// correctness of a particularly complex calculation that was difficult to
+// factor out into something unit-testable (the larger context that code is in
+// *is* unit tested, which should be guard against regressions).  The test
+// code is still in place, guarded by a check against this preprocessor macro;
+// set it to 1 to re-enable that test during development, but be sure to
+// set it back to zero before committing.
+#define LSST_ScaledPolynomialTransformFitter_TEST_IN_PLACE 0
+
+namespace lsst { namespace meas { namespace astrom {
+
+// A singleton struct that manages the schema and keys for polynomial fitting catalogs.
+class ScaledPolynomialTransformFitter::Keys {
+public:
+    afw::table::Schema schema;
+    afw::table::Key<afw::table::RecordId> refId;
+    afw::table::Key<afw::table::RecordId> srcId;
+    afw::table::Point2DKey output;
+    afw::table::Point2DKey input;
+    afw::table::Point2DKey initial;
+    afw::table::Point2DKey model;
+    afw::table::CovarianceMatrixKey<float,2> outputErr;
+    // We use uint16 instead of Flag since it's the only bool we have here, we
+    // may want NumPy views, and afw::table doesn't support [u]int8 fields.
+    afw::table::Key<std::uint16_t> valid;
+
+    Keys(Keys const &) = delete;
+    Keys(Keys &&) = delete;
+    Keys & operator=(Keys const &) = delete;
+    Keys & operator=(Keys &&) = delete;
+
+    static Keys const & forMatches() {
+        static Keys const it(0);
+        return it;
+    }
+
+    static Keys const & forGrid() {
+        static Keys const it;
+        return it;
+    }
+
+private:
+
+    Keys(int) :
+        schema(),
+        refId(schema.addField<afw::table::RecordId>("ref_id", "ID of reference object in this match.")),
+        srcId(schema.addField<afw::table::RecordId>("src_id", "ID of source object in this match.")),
+        output(
+            afw::table::Point2DKey::addFields(
+                schema, "src", "source positions in pixel coordinates.", "pix"
+            )
+        ),
+        input(
+            afw::table::Point2DKey::addFields(
+                schema, "intermediate", "reference positions in intermediate world coordinates", "deg"
+            )
+        ),
+        initial(
+            afw::table::Point2DKey::addFields(
+                schema, "initial", "reference positions transformed by initial WCS", "pix"
+            )
+        ),
+        model(
+            afw::table::Point2DKey::addFields(
+                schema, "model", "result of applying transform to reference positions", "pix"
+            )
+        ),
+        outputErr(
+            afw::table::CovarianceMatrixKey<float,2>::addFields(
+                schema, "src", {"x", "y"}, "pix"
+            )
+        ),
+        valid(schema.addField<std::uint16_t>("valid", "Nonzero if the match should be used in the fit."))
+    {
+        schema.getCitizen().markPersistent();
+    }
+
+    Keys() :
+        schema(),
+        output(
+            afw::table::Point2DKey::addFields(
+                schema, "output", "grid output positions in intermediate world coordinates", "deg"
+            )
+        ),
+        input(
+            afw::table::Point2DKey::addFields(
+                schema, "input", "grid input positions in pixel coordinates.", "pix"
+            )
+        ),
+        model(
+            afw::table::Point2DKey::addFields(
+                schema, "model", "result of applying transform to input positions", "deg"
+            )
+        )
+    {
+        schema.getCitizen().markPersistent();
+    }
+
+};
+
+namespace {
+
+// Return the AffineTransforms that maps the given (x,y) coordinates to lie within (-1, 1)x(-1, 1)
+afw::geom::AffineTransform computeScaling(
+    afw::table::BaseCatalog const & data,
+    afw::table::Point2DKey const & key
+) {
+    afw::geom::Box2D bbox;
+    for (auto const & record : data) {
+        bbox.include(afw::geom::Point2D(record.get(key)));
+    };
+    return afw::geom::AffineTransform(
+        afw::geom::LinearTransform::makeScaling(0.5*bbox.getWidth(), 0.5*bbox.getHeight())
+    ).invert() * afw::geom::AffineTransform(-afw::geom::Extent2D(bbox.getCenter()));
+}
+
+} // anonymous
+
+ScaledPolynomialTransformFitter ScaledPolynomialTransformFitter::fromMatches(
+    int maxOrder,
+    afw::table::ReferenceMatchVector const & matches,
+    afw::image::Wcs const & initialWcs,
+    double intrinsicScatter
+) {
+    Keys const & keys = Keys::forMatches();
+    afw::table::BaseCatalog catalog(keys.schema);
+    catalog.reserve(matches.size());
+    float var2 = intrinsicScatter*intrinsicScatter;
+    for (auto const & match : matches) {
+        auto record = catalog.addNew();
+        record->set(keys.refId, match.first->getId());
+        record->set(keys.srcId, match.second->getId());
+        record->set(keys.input, initialWcs.skyToIntermediateWorldCoord(match.first->getCoord()));
+        record->set(keys.initial, initialWcs.skyToPixel(match.first->getCoord()));
+        record->set(keys.output, match.second->getCentroid());
+        record->set(keys.outputErr, match.second->getCentroidErr() + var2*Eigen::Matrix2f::Identity());
+        record->set(keys.valid, true);
+    }
+    return ScaledPolynomialTransformFitter(
+        catalog,
+        keys,
+        maxOrder,
+        intrinsicScatter,
+        computeScaling(catalog, keys.input),
+        computeScaling(catalog, keys.output)
+    );
+}
+
+ScaledPolynomialTransformFitter ScaledPolynomialTransformFitter::fromGrid(
+    int maxOrder,
+    afw::geom::Box2D const & bbox,
+    int nGridX, int nGridY,
+    ScaledPolynomialTransform const & toInvert
+) {
+    Keys const & keys = Keys::forGrid();
+    afw::table::BaseCatalog catalog(keys.schema);
+    catalog.reserve(nGridX*nGridY);
+    afw::geom::Extent2D dx(bbox.getWidth()/nGridX, 0.0);
+    afw::geom::Extent2D dy(0.0, bbox.getHeight()/nGridY);
+    for (int iy = 0; iy < nGridY; ++iy) {
+        for (int ix = 0; ix < nGridX; ++ix) {
+            afw::geom::Point2D point = bbox.getMin() + dx*ix + dy*iy;
+            auto record = catalog.addNew();
+            record->set(keys.output, point);
+            record->set(keys.input, toInvert(point));
+        }
+    }
+    return ScaledPolynomialTransformFitter(
+        catalog,
+        keys,
+        maxOrder,
+        0.0,
+        computeScaling(catalog, keys.input),
+        computeScaling(catalog, keys.output)
+    );
+}
+
+ScaledPolynomialTransformFitter::ScaledPolynomialTransformFitter(
+    afw::table::BaseCatalog const & data,
+    Keys const & keys,
+    int maxOrder,
+    double intrinsicScatter,
+    afw::geom::AffineTransform const & inputScaling,
+    afw::geom::AffineTransform const & outputScaling
+) :
+    _keys(keys),
+    _intrinsicScatter(intrinsicScatter),
+    _data(data),
+    _outputScaling(outputScaling),
+    _transform(
+        PolynomialTransform(maxOrder),
+        inputScaling,
+        outputScaling.invert()
+    ),
+    _vandermonde(data.size(), detail::computePackedSize(maxOrder))
+{
+    // Create a matrix that evaluates the max-order polynomials of all the (scaled) input positions;
+    // we'll extract subsets of this later when fitting to a subset of the matches and a lower order.
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        afw::geom::Point2D input = getInputScaling()(_data[i].get(_keys.input));
+        // x[k] == pow(x, k), y[k] == pow(y, k)
+        detail::computePowers(_transform._poly._u, input.getX());
+        detail::computePowers(_transform._poly._v, input.getY());
+        // We pack coefficients in the following order:
+        // (0,0), (0,1), (1,0), (0,2), (1,1), (2,0)
+        // Note that this lets us choose the just first N(N+1)/2 columns to
+        // evaluate an Nth order polynomial, even if N < maxOrder.
+        for (int n = 0, j = 0; n <= maxOrder; ++n) {
+            for (int p = 0, q = n; p <= n; ++p, --q, ++j) {
+                _vandermonde(i, j) = _transform._poly._u[p] * _transform._poly._v[q];
+            }
+        }
+    }
+}
+
+void ScaledPolynomialTransformFitter::fit(int order) {
+    int maxOrder = _transform.getPoly().getOrder();
+    if (order < 0) {
+        order = maxOrder;
+    }
+    if (order > maxOrder) {
+        throw LSST_EXCEPT(
+            pex::exceptions::LengthError,
+            (boost::format("Order (%d) exceeded maximum order for the fitter (%d)")
+                % order % maxOrder).str()
+        );
+    }
+
+    int const packedSize = detail::computePackedSize(order);
+    std::size_t nGood = 0;
+    if (_keys.valid.isValid()) {
+        for (auto const & record : _data) {
+            if (record.get(_keys.valid)) {
+                ++nGood;
+            }
+        }
+    } else {
+        nGood = _data.size();
+    }
+    // One block of the block-diagonal (2x2) unweighted design matrix M;
+    // m[i,j] = u_i^{p(j)} v_i^{q(j)}.  The two nonzero blocks are the same,
+    // because we're using the same polynomial basis for x and y.
+    Eigen::MatrixXd m = Eigen::MatrixXd::Zero(nGood, packedSize);
+    // vx, vy: (2x1) blocks of the unweighted data vector v
+    Eigen::VectorXd vx = Eigen::VectorXd::Zero(nGood);
+    Eigen::VectorXd vy = Eigen::VectorXd::Zero(nGood);
+    // sxx, syy, sxy: (2x2) blocks of the covariance matrix S, each of which is
+    // individually diagonal.
+    Eigen::ArrayXd sxx(nGood);
+    Eigen::ArrayXd syy(nGood);
+    Eigen::ArrayXd sxy(nGood);
+    Eigen::Matrix2d outS = _outputScaling.getLinear().getMatrix();
+    for (std::size_t i1 = 0, i2 = 0; i1 < _data.size(); ++i1) {
+        if (!_keys.valid.isValid() || _data[i1].get(_keys.valid)) {
+            afw::geom::Point2D output = _outputScaling(_data[i1].get(_keys.output));
+            vx[i2] = output.getX();
+            vy[i2] = output.getY();
+            m.row(i2) = _vandermonde.row(i1).head(packedSize);
+            if (_keys.outputErr.isValid()) {
+                Eigen::Matrix2d modelErr = outS*_data[i1].get(_keys.outputErr).cast<double>()*outS.adjoint();
+                sxx[i2] = modelErr(0, 0);
+                sxy[i2] = modelErr(0, 1);
+                syy[i2] = modelErr(1, 1);
+            } else {
+                sxx[i2] = 1.0;
+                sxy[i2] = 0.0;
+                syy[i2] = 1.0;
+            }
+            ++i2;
+        }
+    }
+    // Do a blockwise inverse of S.  Note that the result F is still symmetric
+    Eigen::ArrayXd fxx = 1.0/(sxx - sxy.square()/syy);
+    Eigen::ArrayXd fyy = 1.0/(syy - sxy.square()/sxx);
+    Eigen::ArrayXd fxy = -(sxy/sxx)*fyy;
+#ifdef LSST_ScaledPolynomialTransformFitter_TEST_IN_PLACE
+    assert((sxx*fxx + sxy*fxy).isApproxToConstant(1.0));
+    assert((syy*fyy + sxy*fxy).isApproxToConstant(1.0));
+    assert((sxx*fxy).isApprox(-sxy*fyy));
+    assert((sxy*fxx).isApprox(-syy*fxy));
+#endif
+    // Now that we've got all the block quantities, we'll form the full normal equations matrix.
+    // That's H = M^T F M:
+    Eigen::MatrixXd h(2*packedSize, 2*packedSize);
+    h.topLeftCorner(packedSize, packedSize) = m.adjoint() * fxx.matrix().asDiagonal() * m;
+    h.topRightCorner(packedSize, packedSize) = m.adjoint() * fxy.matrix().asDiagonal() * m;
+    h.bottomLeftCorner(packedSize, packedSize) = h.topRightCorner(packedSize, packedSize).adjoint();
+    h.bottomRightCorner(packedSize, packedSize) = m.adjoint() * fyy.matrix().asDiagonal() * m;
+    // And here's the corresponding RHS vector, g = M^T F v
+    Eigen::VectorXd g(2*packedSize);
+    g.head(packedSize) = m.adjoint() * (fxx.matrix().asDiagonal()*vx + fxy.matrix().asDiagonal()*vy);
+    g.tail(packedSize) = m.adjoint() * (fxy.matrix().asDiagonal()*vx + fyy.matrix().asDiagonal()*vy);
+    // Solve the normal equations.
+    auto lstsq = afw::math::LeastSquares::fromNormalEquations(h, g);
+    auto solution = lstsq.getSolution();
+    // Unpack the solution vector back into the polynomial coefficient matrices.
+    for (int n = 0, j = 0; n <= order; ++n) {
+        for (int p = 0, q = n; p <= n; ++p, --q, ++j) {
+            _transform._poly._xCoeffs(p, q) = solution[j];
+            _transform._poly._yCoeffs(p, q) = solution[j + packedSize];
+        }
+    }
+}
+
+void ScaledPolynomialTransformFitter::updateModel() {
+    for (auto & record : _data) {
+        record.set(
+            _keys.model,
+            _transform(record.get(_keys.input))
+        );
+    }
+}
+
+double ScaledPolynomialTransformFitter::updateIntrinsicScatter() {
+    if (!_keys.valid.isValid()) {
+        throw LSST_EXCEPT(
+            pex::exceptions::LogicError,
+            "Cannot compute intrinsic scatter on fitter initialized with fromGrid."
+        );
+    }
+    double newIntrinsicScatter = computeIntrinsicScatter();
+    float varDiff = newIntrinsicScatter*newIntrinsicScatter - _intrinsicScatter*_intrinsicScatter;
+    for (auto & record : _data) {
+        record.set(_keys.outputErr, record.get(_keys.outputErr) + varDiff*Eigen::Matrix2f::Identity());
+    }
+    _intrinsicScatter = newIntrinsicScatter;
+    return _intrinsicScatter;
+}
+
+double ScaledPolynomialTransformFitter::computeIntrinsicScatter() const {
+    // We model the variance matrix of each match as the sum of the intrinsic variance (which we're
+    // trying to fit) and the per-source measurement uncertainty.
+    // We start by computing the variance directly, which yields the sum.
+    // At the same time, we find the maximum per-source variance.  Since the per-source uncertainties
+    // are actually 2x2 matrices, we use the square of the major axis of that ellipse.
+    double directVariance = 0.0; // direct estimate of total scatter (includes measurement errors)
+    double maxMeasurementVariance = 0.0; // maximum of the per-match measurement uncertainties
+    double oldIntrinsicVariance = _intrinsicScatter*_intrinsicScatter;
+    std::size_t nGood = 0;
+    for (auto const & record : _data) {
+        if (!_keys.valid.isValid() || record.get(_keys.valid)) {
+            auto delta = record.get(_keys.output) - record.get(_keys.model);
+            directVariance += 0.5*delta.computeSquaredNorm();
+            double cxx = _keys.outputErr.getElement(record, 0, 0) - oldIntrinsicVariance;
+            double cyy = _keys.outputErr.getElement(record, 1, 1) - oldIntrinsicVariance;
+            double cxy = _keys.outputErr.getElement(record, 0, 1);
+            // square of semimajor axis of uncertainty error ellipse
+            double ca2 = 0.5*(cxx + cyy + std::sqrt(cxx*cxx + cyy*cyy + 4*cxy*cxy - 2*cxx*cyy));
+            maxMeasurementVariance = std::max(maxMeasurementVariance, ca2);
+            ++nGood;
+        }
+    }
+    directVariance /= nGood;
+
+    // Function that computes the -log likelihood of the current deltas with
+    // the variance modeled as described above.
+    auto logLikelihood = [this](double intrinsicVariance) {
+        // Uncertainties in the table right now include the old intrinsic scatter; need to
+        // subtract it off as we add the new one in.
+        double varDiff = intrinsicVariance - this->_intrinsicScatter*this->_intrinsicScatter;
+        double q = 0.0;
+        for (auto & record : this->_data) {
+            double x = record.get(this->_keys.output.getX()) - record.get(_keys.model.getX());
+            double y = record.get(this->_keys.output.getY()) - record.get(_keys.model.getY());
+            double cxx = this->_keys.outputErr.getElement(record, 0, 0) + varDiff;
+            double cyy = this->_keys.outputErr.getElement(record, 1, 1) + varDiff;
+            double cxy = this->_keys.outputErr.getElement(record, 0, 1);
+            double det = cxx*cyy - cxy*cxy;
+            q += (x*x*cyy - 2*x*y*cxy + y*y*cxx)/det + std::log(det);
+        }
+        return q;
+    };
+
+    // directVariance brackets the intrinsic variance from above, and this quantity
+    // brackets it from below:
+    double minIntrinsicVariance = std::max(0.0, directVariance - maxMeasurementVariance);
+
+    // Minimize the negative log likelihood to find the best-fit intrinsic variance.
+    static constexpr int BITS_REQUIRED = 16;  // solution good to ~1E-4
+    boost::uintmax_t maxIterations = 20;
+    auto result = boost::math::tools::brent_find_minima(
+        logLikelihood,
+        minIntrinsicVariance,
+        directVariance,
+        BITS_REQUIRED,
+        maxIterations
+    );
+    return std::sqrt(result.first);  // return RMS instead of variance
+}
+
+
+std::pair<double,std::size_t> ScaledPolynomialTransformFitter::rejectOutliers(
+    OutlierRejectionControl const & ctrl
+) {
+    if (!_keys.valid.isValid()) {
+        throw LSST_EXCEPT(
+            pex::exceptions::LogicError,
+            "Cannot reject outliers on fitter initialized with fromGrid."
+        );
+    }
+    if (static_cast<std::size_t>(ctrl.nClipMin) >= _data.size()) {
+        throw LSST_EXCEPT(
+            pex::exceptions::LogicError,
+            (boost::format("Not enough values (%d) to clip %d.")
+                % _data.size() % ctrl.nClipMin).str()
+        );
+    }
+    std::map<double,afw::table::BaseRecord *> rankings;
+    for (auto & record : _data) {
+        Eigen::Matrix2d cov = record.get(_keys.outputErr).cast<double>();
+        Eigen::Vector2d d = (record.get(_keys.output) - record.get(_keys.model)).asEigen();
+        double r2 = d.dot(cov.inverse() * d);
+        rankings.insert(std::make_pair(r2, &record));
+    }
+    auto cutoff = rankings.upper_bound(ctrl.nSigma * ctrl.nSigma);
+    int nClip = 0, nGood = 0;
+    for (auto iter = rankings.begin(); iter != cutoff; ++iter) {
+        iter->second->set(_keys.valid, true);
+        ++nGood;
+    }
+    for (auto iter = cutoff; iter != rankings.end(); ++iter) {
+        iter->second->set(_keys.valid, false);
+        ++nClip;
+    }
+    assert(static_cast<std::size_t>(nGood + nClip) == _data.size());
+    while (nClip < ctrl.nClipMin) {
+        --cutoff;
+        cutoff->second->set(_keys.valid, false);
+        ++nClip;
+    }
+    while (nClip > ctrl.nClipMax && cutoff != rankings.end()) {
+        cutoff->second->set(_keys.valid, true);
+        ++cutoff;
+        --nClip;
+    }
+    std::pair<double,std::size_t> result(ctrl.nSigma, nClip);
+    if (cutoff != rankings.end()) {
+        result.first = std::sqrt(cutoff->first);
+    }
+    return result;
+}
+
+
+
+}}} // namespace lsst::meas::astrom

--- a/src/SipTransform.cc
+++ b/src/SipTransform.cc
@@ -1,0 +1,202 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * Copyright 2016 LSST/AURA
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#include <sstream>
+
+#include "lsst/afw/coord/Coord.h"
+#include "lsst/afw/image/TanWcs.h"
+#include "lsst/meas/astrom/SipTransform.h"
+
+namespace lsst { namespace meas { namespace astrom {
+
+SipForwardTransform SipForwardTransform::convert(
+    PolynomialTransform const & poly,
+    afw::geom::Point2D const & pixelOrigin,
+    afw::geom::LinearTransform const & cdMatrix
+) {
+    auto forwardSipPoly = compose(
+        afw::geom::AffineTransform(cdMatrix.invert()),
+        compose(
+            poly,
+            afw::geom::AffineTransform(afw::geom::Extent2D(pixelOrigin))
+        )
+    );
+    // Subtracting 1 here accounts for the extra terms outside the sum in the
+    // transform definition (see class docs) - note that you can fold those
+    // terms into the sum by adding 1 from the A_10 and B_01 terms.
+    forwardSipPoly._xCoeffs(1, 0) -= 1;
+    forwardSipPoly._yCoeffs(0, 1) -= 1;
+    return SipForwardTransform(pixelOrigin, cdMatrix, forwardSipPoly);
+}
+
+SipForwardTransform SipForwardTransform::convert(
+    ScaledPolynomialTransform const & scaled,
+    afw::geom::Point2D const & pixelOrigin,
+    afw::geom::LinearTransform const & cdMatrix
+) {
+    auto forwardSipPoly = compose(
+        afw::geom::AffineTransform(cdMatrix.invert())*scaled.getOutputScalingInverse(),
+        compose(
+            scaled.getPoly(),
+            scaled.getInputScaling()*afw::geom::AffineTransform(afw::geom::Extent2D(pixelOrigin))
+        )
+    );
+    // Account for the terms outside the sum in the definition (see comment
+    // earlier in the file for more explanation).
+    forwardSipPoly._xCoeffs(1, 0) -= 1;
+    forwardSipPoly._yCoeffs(0, 1) -= 1;
+    return SipForwardTransform(pixelOrigin, cdMatrix, forwardSipPoly);
+}
+
+SipForwardTransform SipForwardTransform::convert(ScaledPolynomialTransform const & scaled) {
+    afw::geom::Point2D pixelOrigin(-scaled.getOutputScalingInverse().getTranslation());
+    afw::geom::LinearTransform cdMatrix(scaled.getInputScaling().getLinear().invert());
+    return convert(scaled, pixelOrigin, cdMatrix);
+}
+
+afw::geom::AffineTransform SipForwardTransform::linearize(afw::geom::Point2D const & in) const {
+    afw::geom::AffineTransform tail(-afw::geom::Extent2D(getPixelOrigin()));
+    return afw::geom::AffineTransform(_cdMatrix)
+        * (afw::geom::AffineTransform() + _poly.linearize(tail(in)))
+        * tail;
+}
+
+afw::geom::Point2D SipForwardTransform::operator()(afw::geom::Point2D const & uv) const {
+    afw::geom::Point2D duv(uv - afw::geom::Extent2D(getPixelOrigin()));
+    return getCDMatrix()(afw::geom::Extent2D(duv) + getPoly()(duv));
+}
+
+SipReverseTransform SipReverseTransform::convert(
+    PolynomialTransform const & poly,
+    afw::geom::Point2D const & pixelOrigin,
+    afw::geom::LinearTransform const & cdMatrix
+) {
+    auto reverseSipPoly = compose(
+        afw::geom::AffineTransform(-afw::geom::Extent2D(pixelOrigin)),
+        compose(
+            poly,
+            afw::geom::AffineTransform(cdMatrix)
+        )
+    );
+    // Account for the terms outside the sum in the definition (see comment
+    // earlier in the file for more explanation).
+    reverseSipPoly._xCoeffs(1, 0) -= 1;
+    reverseSipPoly._yCoeffs(0, 1) -= 1;
+    return SipReverseTransform(pixelOrigin, cdMatrix, reverseSipPoly);
+}
+
+SipReverseTransform SipReverseTransform::convert(
+    ScaledPolynomialTransform const & scaled,
+    afw::geom::Point2D const & pixelOrigin,
+    afw::geom::LinearTransform const & cdMatrix
+) {
+    auto reverseSipPoly = compose(
+        afw::geom::AffineTransform(-afw::geom::Extent2D(pixelOrigin))
+        *scaled.getOutputScalingInverse(),
+        compose(
+            scaled.getPoly(),
+            scaled.getInputScaling()*afw::geom::AffineTransform(cdMatrix)
+        )
+    );
+    // Account for the terms outside the sum in the definition (see comment
+    // earlier in the file for more explanation).
+    reverseSipPoly._xCoeffs(1, 0) -= 1;
+    reverseSipPoly._yCoeffs(0, 1) -= 1;
+    return SipReverseTransform(pixelOrigin, cdMatrix, reverseSipPoly);
+}
+
+SipReverseTransform SipReverseTransform::convert(ScaledPolynomialTransform const & scaled) {
+    return convert(
+        scaled,
+        afw::geom::Point2D(scaled.getOutputScalingInverse().getTranslation()),
+        scaled.getInputScaling().getLinear()
+    );
+}
+
+afw::geom::AffineTransform SipReverseTransform::linearize(afw::geom::Point2D const & in) const {
+    return afw::geom::AffineTransform(afw::geom::Extent2D(getPixelOrigin()))
+        * (afw::geom::AffineTransform() + _poly.linearize(_cdInverse(in)))
+        * _cdInverse;
+}
+
+afw::geom::Point2D SipReverseTransform::operator()(afw::geom::Point2D const & xy) const {
+    afw::geom::Point2D UV = _cdInverse(xy);
+    return afw::geom::Extent2D(UV) + afw::geom::Extent2D(getPixelOrigin()) + getPoly()(UV);
+}
+
+
+PTR(afw::image::TanWcs) makeWcs(
+    SipForwardTransform const & sipForward,
+    SipReverseTransform const & sipReverse,
+    afw::coord::Coord const & skyOrigin
+) {
+    if (!sipForward.getPixelOrigin().asEigen().isApprox(sipReverse.getPixelOrigin().asEigen())) {
+        std::ostringstream oss;
+        oss << "SIP forward and reverse transforms have inconsistent CRPIX: "
+            << sipForward.getPixelOrigin() << " != " << sipReverse.getPixelOrigin();
+        throw LSST_EXCEPT(
+            pex::exceptions::InvalidParameterError,
+            oss.str()
+        );
+    }
+    if (!sipForward.getCDMatrix().getMatrix().isApprox(sipReverse.getCDMatrix().getMatrix())) {
+        std::ostringstream oss;
+        oss << "SIP forward and reverse transforms have inconsistent CD matrix: "
+            << sipForward.getCDMatrix() << "\n!=\n" << sipReverse.getCDMatrix();
+        throw LSST_EXCEPT(
+            pex::exceptions::InvalidParameterError,
+            oss.str()
+        );
+    }
+    Eigen::MatrixXd sipA(sipForward.getPoly().getXCoeffs().asEigen());
+    Eigen::MatrixXd sipB(sipForward.getPoly().getYCoeffs().asEigen());
+    Eigen::MatrixXd sipAP(sipReverse.getPoly().getXCoeffs().asEigen());
+    Eigen::MatrixXd sipBP(sipReverse.getPoly().getYCoeffs().asEigen());
+    // TanWcs uses strings for coordinate systems, while Coord uses an enum.
+    // Frustratingly, there's no way to convert from the enum to the string.
+    std::string coordSys;
+    switch (skyOrigin.getCoordSystem()) {
+    case afw::coord::ICRS:
+        coordSys = "ICRS";
+        break;
+    case afw::coord::FK5:
+        coordSys = "FK5";
+        break;
+    default:
+        throw LSST_EXCEPT(
+            pex::exceptions::InvalidParameterError,
+            "Coordinate system not supported"
+        );
+    }
+    return std::make_shared<afw::image::TanWcs>(
+        skyOrigin.getPosition(afw::geom::degrees),
+        sipForward.getPixelOrigin(),
+        sipForward.getCDMatrix().getMatrix(),
+        sipA, sipB, sipAP, sipBP,
+        skyOrigin.getEpoch(),
+        coordSys
+    );
+}
+
+}}} // namespace lsst::meas::astrom

--- a/src/detail/polynomialUtils.cc
+++ b/src/detail/polynomialUtils.cc
@@ -1,0 +1,67 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * Copyright 2016 LSST/AURA
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#include <mutex>
+#include "lsst/meas/astrom/detail/polynomialUtils.h"
+
+namespace lsst { namespace meas { namespace astrom { namespace detail {
+
+void computePowers(Eigen::VectorXd & r, double x) {
+    r[0] = 1.0;
+    for (int i = 1; i < r.size(); ++i) {
+        r[i] = r[i - 1] * x;
+    }
+}
+
+Eigen::VectorXd computePowers(double x, int n) {
+    Eigen::VectorXd r(n + 1);
+    computePowers(r, x);
+    return r;
+}
+
+void BinomialMatrix::extend(int const n) {
+    static std::mutex mutex;
+    auto & old = getMatrix();
+    int const m = old.rows() - 1;
+    if (n <= m) return;
+    Eigen::MatrixXd updated = Eigen::MatrixXd::Zero(n + 1, n + 1);
+    updated.topLeftCorner(old.rows(), old.cols()) = old;
+    for (int i = m + 1; i <= n; ++i) {
+        updated(i, 0) = 1.0;
+        updated(i, i) = 1.0;
+        for (int j = 1; j < i; ++j) {
+            updated(i, j) = updated(i - 1, j - 1) *
+                (static_cast<double>(i) / static_cast<double>(j));
+        }
+    }
+    std::unique_lock<std::mutex> lock(mutex);
+    old.swap(updated);
+}
+
+Eigen::MatrixXd & BinomialMatrix::getMatrix() {
+    static Eigen::MatrixXd it = Eigen::MatrixXd::Constant(2, 2, 1.0);
+    return it;
+}
+
+}}}} // namespace lsst::meas::astrom::detail

--- a/tests/testTransforms.py
+++ b/tests/testTransforms.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python
+from __future__ import absolute_import, division, print_function
+from builtins import range
+
+#
+# LSST Data Management System
+# Copyright 2016 LSST/AURA.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import numpy as np
+import lsst.utils.tests
+import lsst.pex.exceptions
+import lsst.afw.geom
+from lsst.meas.astrom import (
+    PolynomialTransform,
+    ScaledPolynomialTransform,
+    SipForwardTransform,
+    SipReverseTransform,
+    ScaledPolynomialTransformFitter
+)
+
+
+def makeRandomCoefficientMatrix(n):
+    matrix = np.random.randn(n, n)
+    for i in range(1, n):
+        matrix[i, (n-i):] = 0
+    return matrix
+
+
+def makeRandomAffineTransform():
+    return lsst.afw.geom.AffineTransform(
+        lsst.afw.geom.LinearTransform(np.random.randn(2, 2)),
+        lsst.afw.geom.Extent2D(*np.random.randn(2))
+    )
+
+
+def makeRandomPolynomialTransform(order, sip=False):
+    xc = makeRandomCoefficientMatrix(order + 1)
+    yc = makeRandomCoefficientMatrix(order + 1)
+    if sip:
+        xc[0, 0] = 0
+        yc[0, 0] = 0
+        xc[0, 1] = 0
+        yc[0, 1] = 0
+        xc[1, 0] = 0
+        yc[1, 0] = 0
+    return PolynomialTransform(xc, yc)
+
+
+def makeRandomScaledPolynomialTransform(order):
+    return ScaledPolynomialTransform(
+        makeRandomPolynomialTransform(order),
+        makeRandomAffineTransform(),
+        makeRandomAffineTransform()
+    )
+
+
+def makeRandomSipForwardTransform(order):
+    return SipForwardTransform(
+        lsst.afw.geom.Point2D(*np.random.randn(2)),
+        lsst.afw.geom.LinearTransform(np.random.randn(2,2)),
+        makeRandomPolynomialTransform(order, sip=True)
+    )
+
+
+def makeRandomSipReverseTransform(order):
+    origin = lsst.afw.geom.Point2D(*np.random.randn(2))
+    cd = lsst.afw.geom.LinearTransform(np.random.randn(2, 2))
+    poly = makeRandomPolynomialTransform(order, sip=False)
+    return SipReverseTransform(origin, cd, poly)
+
+
+class TransformTestMixin(object):
+
+    def makeRandom(self):
+        """Create an instance of the transform being tested with random testing.
+        """
+        raise NotImplementedError()
+
+    def assertTransformsNearlyEqual(self, a, b, rtol=1E-8):
+        for i in range(10):
+            point = lsst.afw.geom.Point2D(*np.random.randn(2))
+            aOut = a(point)
+            bOut = b(point)
+            self.assertClose(np.array(aOut), np.array(bOut), rtol=rtol)
+
+    def testLinearize(self):
+        """Test that the AffineTransform returned by linearize() is equivalent
+        to the transform at the expansion point, and matches finite differences.
+        """
+        transform = self.makeRandom()
+        point = lsst.afw.geom.Point2D(*np.random.randn(2))
+        affine = transform.linearize(point)
+        self.assertClose(np.array(transform(point)), np.array(affine(point)), rtol=1E-14)
+        delta = 1E-4
+        deltaX = lsst.afw.geom.Extent2D(delta, 0.0)
+        deltaY = lsst.afw.geom.Extent2D(0.0, delta)
+        dtdx = (transform(point + deltaX) - transform(point - deltaX)) / (2*delta)
+        dtdy = (transform(point + deltaY) - transform(point - deltaY)) / (2*delta)
+        self.assertClose(affine[affine.XX], dtdx.getX(), rtol=1E-6)
+        self.assertClose(affine[affine.YX], dtdx.getY(), rtol=1E-6)
+        self.assertClose(affine[affine.XY], dtdy.getX(), rtol=1E-6)
+        self.assertClose(affine[affine.YY], dtdy.getY(), rtol=1E-6)
+
+
+class PolynomialTransformTestCase(lsst.utils.tests.TestCase, TransformTestMixin):
+
+    def setUp(self):
+        np.random.seed(50)
+
+    def makeRandom(self):
+        return makeRandomPolynomialTransform(4)
+
+    def testArrayConstructor(self):
+        """Test that construction with coefficient arrays yields an object with
+        copies of those arrays, and that all dimensions must be the same.
+        """
+        order = 3
+        xc = makeRandomCoefficientMatrix(order + 1)
+        yc = makeRandomCoefficientMatrix(order + 1)
+        p = PolynomialTransform(xc, yc)
+        self.assertEqual(p.getOrder(), order)
+        self.assertClose(p.getXCoeffs(), xc, atol=0, rtol=0)
+        self.assertClose(p.getYCoeffs(), yc, atol=0, rtol=0)
+        # Test that the coefficients are not a view.
+        old = xc[0, 0]
+        xc[0, 0] += 100.0
+        self.assertEqual(p.getXCoeffs()[0, 0], old)
+        # Test that rectangular coefficient arrays are not allowed.
+        self.assertRaises(
+            lsst.pex.exceptions.LengthError,
+            PolynomialTransform,
+            np.zeros((5, 4), dtype=float),
+            np.zeros((5, 4), dtype=float)
+        )
+        # Test that x and y coefficient arrays must have the same shape.
+        self.assertRaises(
+            lsst.pex.exceptions.LengthError,
+            PolynomialTransform,
+            np.zeros((5, 5), dtype=float),
+            np.zeros((4, 4), dtype=float)
+        )
+
+    def testConvertScaledPolynomial(self):
+        """Test that we can convert a ScaledPolynomialTransform to a PolynomialTransform.
+        """
+        scaled = makeRandomScaledPolynomialTransform(4)
+        converted = PolynomialTransform.convert(scaled)
+        self.assertTransformsNearlyEqual(scaled, converted)
+
+    def testConvertSipForward(self):
+        """Test that we can convert a SipForwardTransform to a PolynomialTransform.
+        """
+        sipForward = makeRandomSipForwardTransform(4)
+        converted = PolynomialTransform.convert(sipForward)
+        self.assertTransformsNearlyEqual(sipForward, converted)
+
+    def testConvertSipReverse(self):
+        """Test that we can convert a SipForwardTransform to a PolynomialTransform.
+        """
+        sipReverse = makeRandomSipReverseTransform(4)
+        converted = PolynomialTransform.convert(sipReverse)
+        self.assertTransformsNearlyEqual(sipReverse, converted)
+
+    def testCompose(self):
+        """Test that AffineTransforms and PolynomialTransforms can be composed
+        into an equivalent PolynomialTransform.
+        """
+        poly = makeRandomPolynomialTransform(4)
+        affine = lsst.afw.geom.AffineTransform(
+            lsst.afw.geom.LinearTransform(np.random.randn(2, 2)),
+            lsst.afw.geom.Extent2D(*np.random.randn(2))
+        )
+        composed1 = lsst.meas.astrom.compose(poly, affine)
+        composed2 = lsst.meas.astrom.compose(affine, poly)
+        self.assertTransformsNearlyEqual(composed1, lambda p: poly(affine(p)))
+        self.assertTransformsNearlyEqual(composed2, lambda p: affine(poly(p)))
+        # Test that composition with an identity transform is a no-op
+        composed3 = lsst.meas.astrom.compose(poly, lsst.afw.geom.AffineTransform())
+        composed4 = lsst.meas.astrom.compose(lsst.afw.geom.AffineTransform(), poly)
+        self.assertClose(composed3.getXCoeffs(), poly.getXCoeffs())
+        self.assertClose(composed3.getYCoeffs(), poly.getYCoeffs())
+        self.assertClose(composed4.getXCoeffs(), poly.getXCoeffs())
+        self.assertClose(composed4.getYCoeffs(), poly.getYCoeffs())
+
+
+class ScaledPolynomialTransformTestCase(lsst.utils.tests.TestCase, TransformTestMixin):
+
+    def setUp(self):
+        np.random.seed(50)
+
+    def makeRandom(self):
+        return makeRandomScaledPolynomialTransform(4)
+
+    def testConstruction(self):
+        poly = makeRandomPolynomialTransform(4)
+        inputScaling = makeRandomAffineTransform()
+        outputScalingInverse = makeRandomAffineTransform()
+        scaled = ScaledPolynomialTransform(poly, inputScaling, outputScalingInverse)
+        self.assertTransformsNearlyEqual(
+            scaled,
+            lambda p: outputScalingInverse(poly(inputScaling(p)))
+        )
+
+    def testConvertPolynomial(self):
+        """Test that we can convert a PolynomialTransform to a ScaledPolynomialTransform.
+        """
+        poly = makeRandomPolynomialTransform(4)
+        converted = ScaledPolynomialTransform.convert(poly)
+        self.assertTransformsNearlyEqual(poly, converted)
+
+    def testConvertSipForward(self):
+        """Test that we can convert a SipForwardTransform to a ScaledPolynomialTransform.
+        """
+        sipForward = makeRandomSipForwardTransform(4)
+        converted = ScaledPolynomialTransform.convert(sipForward)
+        self.assertTransformsNearlyEqual(sipForward, converted)
+
+    def testConvertSipReverse(self):
+        """Test that we can convert a SipReverseTransform to a ScaledPolynomialTransform.
+        """
+        sipReverse = makeRandomSipReverseTransform(4)
+        converted = ScaledPolynomialTransform.convert(sipReverse)
+        self.assertTransformsNearlyEqual(sipReverse, converted)
+
+
+class SipForwardTransformTestCase(lsst.utils.tests.TestCase, TransformTestMixin):
+
+    def setUp(self):
+        np.random.seed(50)
+
+    def makeRandom(self):
+        return makeRandomSipForwardTransform(4)
+
+    def testConstruction(self):
+        poly = makeRandomPolynomialTransform(4, sip=True)
+        cd = lsst.afw.geom.LinearTransform(np.random.randn(2, 2))
+        crpix = lsst.afw.geom.Point2D(*np.random.randn(2))
+        sip = SipForwardTransform(crpix, cd, poly)
+        self.assertTransformsNearlyEqual(
+            sip,
+            lambda p: cd((p - crpix) + poly(lsst.afw.geom.Point2D(p - crpix)))
+        )
+
+    def testConvertPolynomial(self):
+        poly = makeRandomPolynomialTransform(4)
+        cd = lsst.afw.geom.LinearTransform(np.random.randn(2, 2))
+        crpix = lsst.afw.geom.Point2D(*np.random.randn(2))
+        sip = lsst.meas.astrom.SipForwardTransform.convert(poly, crpix, cd)
+        self.assertTransformsNearlyEqual(sip, poly)
+
+    def testConvertScaledPolynomialManual(self):
+        scaled = makeRandomScaledPolynomialTransform(4)
+        cd = lsst.afw.geom.LinearTransform(np.random.randn(2, 2))
+        crpix = lsst.afw.geom.Point2D(*np.random.randn(2))
+        sip = lsst.meas.astrom.SipForwardTransform.convert(scaled, crpix, cd)
+        self.assertTransformsNearlyEqual(sip, scaled)
+
+    def testConvertScaledPolynomialAutomatic(self):
+        scaled = makeRandomScaledPolynomialTransform(4)
+        sip = lsst.meas.astrom.SipForwardTransform.convert(scaled)
+        self.assertTransformsNearlyEqual(sip, scaled)
+
+    def testMakeWcs(self):
+        fwd = self.makeRandom()
+        rev = SipReverseTransform(  # this isn't actually the inverse of fwd, but that doesn't matter
+            fwd.getPixelOrigin(),
+            fwd.getCDMatrix(),
+            makeRandomPolynomialTransform(4)
+        )
+        crval = lsst.afw.geom.Point2D(45.0, 45.0)
+        wcs = lsst.meas.astrom.makeWcs(
+            fwd, rev,
+            lsst.afw.coord.IcrsCoord(crval, lsst.afw.geom.degrees)
+        )
+        # We can only test agreement with TanWcs in one direction, because
+        # TanWcs doesn't provide an inverse to skyToIntermediateWorldCoord.
+
+        def t1(p):
+            sky = lsst.afw.coord.IcrsCoord(crval + lsst.afw.geom.Extent2D(p), lsst.afw.geom.degrees)
+            return rev(wcs.skyToIntermediateWorldCoord(sky))
+
+        def t2(p):
+            sky = lsst.afw.coord.IcrsCoord(crval + lsst.afw.geom.Extent2D(p), lsst.afw.geom.degrees)
+            return wcs.skyToPixel(sky)
+
+        self.assertTransformsNearlyEqual(t1, t2)
+
+
+class SipReverseTransformTestCase(lsst.utils.tests.TestCase, TransformTestMixin):
+
+    def setUp(self):
+        np.random.seed(50)
+
+    def makeRandom(self):
+        return makeRandomSipReverseTransform(4)
+
+    def testConstruction(self):
+        poly = makeRandomPolynomialTransform(4)
+        cd = lsst.afw.geom.LinearTransform(np.random.randn(2, 2))
+        crpix = lsst.afw.geom.Point2D(*np.random.randn(2))
+        sip = SipReverseTransform(crpix, cd, poly)
+        offset = lsst.afw.geom.Extent2D(crpix)
+        cdInverse = cd.invert()
+        self.assertTransformsNearlyEqual(
+            sip,
+            lambda p: offset + lsst.afw.geom.Extent2D(cdInverse(p)) + poly(cdInverse(p))
+        )
+
+    def testConvertPolynomial(self):
+        poly = makeRandomPolynomialTransform(4)
+        cd = lsst.afw.geom.LinearTransform(np.random.randn(2, 2))
+        crpix = lsst.afw.geom.Point2D(*np.random.randn(2))
+        sip = lsst.meas.astrom.SipReverseTransform.convert(poly, crpix, cd)
+        self.assertTransformsNearlyEqual(sip, poly)
+
+    def testConvertScaledPolynomialManual(self):
+        scaled = makeRandomScaledPolynomialTransform(4)
+        cd = lsst.afw.geom.LinearTransform(np.random.randn(2, 2))
+        crpix = lsst.afw.geom.Point2D(*np.random.randn(2))
+        sip = lsst.meas.astrom.SipReverseTransform.convert(scaled, crpix, cd)
+        self.assertTransformsNearlyEqual(sip, scaled)
+
+    def testConvertScaledPolynomialAutomatic(self):
+        scaled = makeRandomScaledPolynomialTransform(4)
+        sip = lsst.meas.astrom.SipReverseTransform.convert(scaled)
+        self.assertTransformsNearlyEqual(sip, scaled)
+
+
+class ScaledPolynomialTransformFitterTestCase(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        np.random.seed(50)
+
+    def testFromMatches(self):
+        # Setup artifical matches that correspond to a known (random) PolynomialTransform.
+        order = 3
+        truePoly = makeRandomPolynomialTransform(order)
+        crval = lsst.afw.coord.IcrsCoord(lsst.afw.geom.Point2D(35.0, 10.0), lsst.afw.geom.degrees)
+        crpix = lsst.afw.geom.Point2D(50, 50)
+        cd = lsst.afw.geom.LinearTransform.makeScaling((0.2*lsst.afw.geom.arcseconds).asDegrees())
+        initialWcs = lsst.afw.image.makeWcs(crval, crpix, cd[cd.XX], cd[cd.XY], cd[cd.YX], cd[cd.YY])
+        bbox = lsst.afw.geom.Box2D(
+            (lsst.afw.geom.Point2D(crval.getPosition(lsst.afw.geom.arcseconds))
+                - lsst.afw.geom.Extent2D(20, 20)),
+            (lsst.afw.geom.Point2D(crval.getPosition(lsst.afw.geom.arcseconds))
+                + lsst.afw.geom.Extent2D(20, 20))
+        )
+        srcSchema = lsst.afw.table.SourceTable.makeMinimalSchema()
+        srcPosKey = lsst.afw.table.Point2DKey.addFields(srcSchema, "pos", "source position", "pix")
+        srcErrKey = lsst.afw.table.CovarianceMatrix2fKey.addFields(srcSchema, "pos",
+                                                                   ["x", "y"], ["pix", "pix"])
+        srcSchema.getAliasMap().set("slot_Centroid", "pos")
+        nPoints = 10
+        trueSrc = lsst.afw.table.SourceCatalog(srcSchema)
+        trueSrc.reserve(nPoints)
+        measSrc = lsst.afw.table.SourceCatalog(srcSchema)
+        measSrc.reserve(nPoints)
+        ref = lsst.afw.table.SimpleCatalog(lsst.afw.table.SimpleTable.makeMinimalSchema())
+        ref.reserve(nPoints)
+        refCoordKey = ref.getCoordKey()
+        errScaling = 1E-14
+        matches = lsst.afw.table.ReferenceMatchVector()
+        for i in range(nPoints):
+            refRec = ref.addNew()
+            skyPos = lsst.afw.geom.Point2D(
+                np.random.uniform(low=bbox.getMinX(), high=bbox.getMaxX()),
+                np.random.uniform(low=bbox.getMinY(), high=bbox.getMaxY())
+            )
+            skyCoord = lsst.afw.coord.IcrsCoord(skyPos, lsst.afw.geom.arcseconds)
+            refRec.set(refCoordKey, skyCoord)
+            trueRec = trueSrc.addNew()
+            truePos = truePoly(initialWcs.skyToIntermediateWorldCoord(skyCoord))
+            trueRec.set(srcPosKey, truePos)
+            measRec = measSrc.addNew()
+            covSqrt = np.random.randn(3, 2)
+            cov = (errScaling*(np.dot(covSqrt.transpose(), covSqrt)
+                   + np.diag([1.0, 1.0]))).astype(np.float32)
+            # We don't actually perturb positions according to noise level, as
+            # this makes it much harder to test that the result agrees with
+            # what we put in.
+            measPos = truePos
+            measRec.set(srcPosKey, measPos)
+            measRec.set(srcErrKey, cov)
+            match = lsst.afw.table.ReferenceMatch(refRec, measRec, (measPos - truePos).computeNorm())
+            matches.append(match)
+        # Construct a fitter, and verify that the internal catalog it constructs is what we expect.
+        fitter = ScaledPolynomialTransformFitter.fromMatches(order, matches, initialWcs, 0.0)
+        expected = lsst.meas.astrom.compose(
+            fitter.getOutputScaling(),
+            lsst.meas.astrom.compose(truePoly, fitter.getInputScaling().invert())
+        )
+        data = fitter.getData()
+        dataOutKey = lsst.afw.table.Point2DKey(data.schema["src"])
+        dataInKey = lsst.afw.table.Point2DKey(data.schema["intermediate"])
+        dataErrKey = lsst.afw.table.CovarianceMatrix2fKey(data.schema["src"], ["x", "y"])
+        scaledInBBox = lsst.afw.geom.Box2D()
+        scaledOutBBox = lsst.afw.geom.Box2D()
+        vandermonde = np.zeros((nPoints, (order + 1)*(order + 2)//2), dtype=float)
+        for i, (match, dataRec, trueRec) in enumerate(zip(matches, data, trueSrc)):
+            self.assertEqual(match.second.getX(), dataRec.get("src_x"))
+            self.assertEqual(match.second.getY(), dataRec.get("src_y"))
+            self.assertEqual(match.first.getId(), dataRec.get("ref_id"))
+            self.assertEqual(match.second.getId(), dataRec.get("src_id"))
+            refPos = initialWcs.skyToIntermediateWorldCoord(match.first.getCoord())
+            self.assertEqual(refPos.getX(), dataRec.get("intermediate_x"))
+            self.assertEqual(refPos.getY(), dataRec.get("intermediate_y"))
+            self.assertClose(match.second.get(srcErrKey), dataRec.get(dataErrKey), rtol=1E-7)
+            scaledIn = fitter.getInputScaling()(dataRec.get(dataInKey))
+            scaledOut = fitter.getOutputScaling()(dataRec.get(dataOutKey))
+            scaledInBBox.include(scaledIn)
+            scaledOutBBox.include(scaledOut)
+            self.assertClose(np.array(expected(scaledIn)), np.array(scaledOut), rtol=1E-7)
+            j = 0
+            for n in range(order + 1):
+                for p in range(n + 1):
+                    q = n - p
+                    vandermonde[i, j] = scaledIn.getX()**p * scaledIn.getY()**q
+                    j += 1
+        # Verify that scaling transforms move inputs and outputs into [-1, 1]
+        self.assertClose(scaledInBBox.getMinX(), -1.0, rtol=1E-12)
+        self.assertClose(scaledInBBox.getMinY(), -1.0, rtol=1E-12)
+        self.assertClose(scaledInBBox.getMaxX(), 1.0, rtol=1E-12)
+        self.assertClose(scaledInBBox.getMaxY(), 1.0, rtol=1E-12)
+        self.assertClose(scaledOutBBox.getMinX(), -1.0, rtol=1E-12)
+        self.assertClose(scaledOutBBox.getMinY(), -1.0, rtol=1E-12)
+        self.assertClose(scaledOutBBox.getMaxX(), 1.0, rtol=1E-12)
+        self.assertClose(scaledOutBBox.getMaxY(), 1.0, rtol=1E-12)
+        # Run the fitter, and check that we get out approximately what we put in.
+        fitter.fit(order)
+        fitter.updateModel()
+        # Check the transformed input points.
+        self.assertClose(data.get("model_x"), trueSrc.getX(), rtol=1E-15)
+        self.assertClose(data.get("model_y"), trueSrc.getY(), rtol=1E-15)
+        # Check the actual transform's coefficients (after composing in the scaling, which is
+        # a lot of the reason we lose a lot of precision here).
+        fittedPoly = lsst.meas.astrom.PolynomialTransform.convert(fitter.getTransform())
+        self.assertClose(fittedPoly.getXCoeffs(), truePoly.getXCoeffs(), rtol=1E-5, atol=1E-5)
+        self.assertClose(fittedPoly.getYCoeffs(), truePoly.getYCoeffs(), rtol=1E-5, atol=1E-5)
+
+    def testFromGrid(self):
+        outOrder = 8
+        inOrder = 2
+        toInvert = makeRandomScaledPolynomialTransform(inOrder)
+        bbox = lsst.afw.geom.Box2D(lsst.afw.geom.Point2D(432, -671), lsst.afw.geom.Point2D(527, -463))
+        fitter = ScaledPolynomialTransformFitter.fromGrid(outOrder, bbox, 50, 50, toInvert)
+        fitter.fit(outOrder)
+        fitter.updateModel()
+        data = fitter.getData()
+        result = fitter.getTransform()
+        inputKey = lsst.afw.table.Point2DKey(data.schema["input"])
+        outputKey = lsst.afw.table.Point2DKey(data.schema["output"])
+        for record in data:
+            self.assertClose(np.array(record.get(inputKey)), np.array(toInvert(record.get(outputKey))))
+            self.assertClose(
+                np.array(result(record.get(inputKey))),
+                np.array(record.get(outputKey)),
+                rtol=1E-2  # even at much higher order, inverse can't be perfect.
+            )
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This adds a new fitter for SIP distortions in the form of a number of C++ classes (several polynomial-based transform classes and a fitter) and a new Python task that is intended as a drop-in replacement for `FitTanSipWcsTask`.

Some caveats:

 - I have not yet enabled the new task, `FitSipDistortionTask`, as the default; I think it needs a bit more testing before we do that.  I do however expect it to fully replace `FitTanSipWcsTask` eventually, so I have not tried to more strictly define the interface for WCS fitters or add a registry as we do with other pluggable tasks.  I also have ignored some (minor) code duplication between the tasks (especially their config classes) that would be better to clean up with common base class if we expected them to coexist for a long time.

 - The new transform classes do not inherit from `XYTransform` or any other common base class, and that probably limits their usefulness to this particular application.  I think we'll want to refactor that when we have our new WCS/transform library, but doing it before then is probably premature.
