### PR TITLE
Only import matplotlib when needed

### DIFF
--- a/python/lsst/meas/astrom/anetBasicAstrometry.py
+++ b/python/lsst/meas/astrom/anetBasicAstrometry.py
@@ -726,9 +726,8 @@ class ANetBasicAstrometryTask(pipeBase.Task):
 
         try:
             import matplotlib.pyplot as plt
-            import numpy
-        except ImportError:
-            print("Unable to import matplotlib", file=sys.stderr)
+        except ImportError as e:
+            self.log.warning("Unable to import matplotlib: %s", e)
             return
 
         fig = plt.figure(1)
@@ -739,10 +738,10 @@ class ANetBasicAstrometryTask(pipeBase.Task):
             pass
 
         num = len(matches)
-        x = numpy.zeros(num)
-        y = numpy.zeros(num)
-        dx = numpy.zeros(num)
-        dy = numpy.zeros(num)
+        x = np.zeros(num)
+        y = np.zeros(num)
+        dx = np.zeros(num)
+        dy = np.zeros(num)
         for i, m in enumerate(matches):
             x[i] = m.second.getX()
             y[i] = m.second.getY()

--- a/python/lsst/meas/astrom/fitTanSipWcs.py
+++ b/python/lsst/meas/astrom/fitTanSipWcs.py
@@ -239,7 +239,11 @@ class FitTanSipWcsTask(pipeBase.Task):
         We create four plots, for all combinations of (dx, dy) against
         (x, y).  Good points are black, while rejected points are red.
         """
-        import matplotlib.pyplot as plt
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError as e:
+            self.log.warn("Unable to import matplotlib: %s", e)
+            return
 
         fit = [wcs.skyToPixel(m.first.getCoord()) for m in matches]
         x1 = np.array([ff.getX() for ff in fit])

--- a/python/lsst/meas/astrom/sip/cleanBadPoints.py
+++ b/python/lsst/meas/astrom/sip/cleanBadPoints.py
@@ -89,14 +89,14 @@ def indicesOfGoodPoints(x, y, s, order=1, nsigma=3, maxiter=100):
         newidx = np.flatnonzero(deviance < nsigma)
 
         if False:
-            import matplotlib.pyplot as mpl
-            mpl.plot(x, y, 'ks')
-            mpl.plot(rx, ry, 'b-')
-            mpl.plot(rx, ry, 'bs')
-            mpl.plot(rx, fit, 'ms')
-            mpl.plot(rx, fit, 'm-')
-            #mpl.plot(x[newidx], y[newidx], 'rs')
-            mpl.show()
+            import matplotlib.pyplot as plt
+            plt.plot(x, y, 'ks')
+            plt.plot(rx, ry, 'b-')
+            plt.plot(rx, ry, 'bs')
+            plt.plot(rx, fit, 'ms')
+            plt.plot(rx, fit, 'm-')
+            #plt.plot(x[newidx], y[newidx], 'rs')
+            plt.show()
 
         # If we haven't culled any points we're finished cleaning
         if len(newidx) == len(idx):

--- a/tests/testFitTanSipWcsHighOrder.py
+++ b/tests/testFitTanSipWcsHighOrder.py
@@ -2,7 +2,6 @@
 import unittest
 
 import numpy as np
-import matplotlib.pylab as pylab
 
 import lsst.utils.tests
 import lsst.daf.base as dafBase
@@ -80,6 +79,7 @@ class ApproximateWcsTestCase(lsst.utils.tests.TestCase):
                                           maxDiffSky=0.001*afwGeom.arcseconds, maxDiffPix=0.02, msg=msg)
 
     def plotWcs(self, wcs0, wcs1, bbox, xyTransform):
+        import matplotlib.pyplot as plt
         bboxd = afwGeom.Box2D(bbox)
         x0Arr = []
         y0Arr = []
@@ -99,9 +99,9 @@ class ApproximateWcsTestCase(lsst.utils.tests.TestCase):
                 y1Arr.append(pixelPos1[1])
                 x2Arr.append(distortedPos[0])
                 y2Arr.append(distortedPos[1])
-        pylab.plot(x0Arr, y0Arr, 'b+', x1Arr, y1Arr, 'rx', x2Arr, y2Arr, 'g.')
+        plt.plot(x0Arr, y0Arr, 'b+', x1Arr, y1Arr, 'rx', x2Arr, y2Arr, 'g.')
 
-        pylab.show()
+        plt.show()
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/testFitTanSipWcsTask.py
+++ b/tests/testFitTanSipWcsTask.py
@@ -38,12 +38,6 @@ import math
 import unittest
 
 import numpy as np
-try:
-    import matplotlib
-    matplotlib.use("Agg")
-    import pylab
-except ImportError:
-    pass
 
 import lsst.pipe.base
 import lsst.utils.tests
@@ -237,6 +231,9 @@ class BaseTestCase(object):
             self.checkResults(fitRes, catsUpdated=True)
 
     def plotWcs(self, tanSipWcs, name=""):
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
         fileNamePrefix = "testCreateWcsWithSip_%s_%s" % (self.MatchClass.__name__, name)
         pnum = 1
 
@@ -258,32 +255,32 @@ class BaseTestCase(object):
         xc = np.array(xc)
         yc = np.array(yc)
 
-        pylab.clf()
-        pylab.plot(xs, ys, "r.")
-        pylab.plot(xc, yc, "bx")
+        plt.clf()
+        plt.plot(xs, ys, "r.")
+        plt.plot(xc, yc, "bx")
         fileName = "%s_%i.png" % (fileNamePrefix, pnum)
-        pylab.savefig(fileName)
+        plt.savefig(fileName)
         print("Wrote", fileName)
         pnum += 1
 
-        pylab.clf()
-        pylab.plot(xs, xc-xs, "b.")
+        plt.clf()
+        plt.plot(xs, xc-xs, "b.")
         fileName = "%s_%i.png" % (fileNamePrefix, pnum)
-        pylab.xlabel("x(source)")
-        pylab.ylabel("x(ref - src)")
-        pylab.savefig(fileName)
+        plt.xlabel("x(source)")
+        plt.ylabel("x(ref - src)")
+        plt.savefig(fileName)
         print("Wrote", fileName)
         pnum += 1
 
-        pylab.clf()
-        pylab.plot(rs, ds, "r.")
-        pylab.plot(rc, dc, "bx")
+        plt.clf()
+        plt.plot(rs, ds, "r.")
+        plt.plot(rc, dc, "bx")
         fileName = "%s_%i.png" % (fileNamePrefix, pnum)
-        pylab.savefig(fileName)
+        plt.savefig(fileName)
         print("Wrote", fileName)
         pnum += 1
 
-        pylab.clf()
+        plt.clf()
         for y in np.linspace(0, 4000, 5):
             x0, y0 = [], []
             x1, y1 = [], []
@@ -296,9 +293,9 @@ class BaseTestCase(object):
                 y1.append(xy[1])
             x0 = np.array(x0)
             x1 = np.array(x1)
-            pylab.plot(x0, x1-x0, "b-")
+            plt.plot(x0, x1-x0, "b-")
         fileName = "%s_%i.png" % (fileNamePrefix, pnum)
-        pylab.savefig(fileName)
+        plt.savefig(fileName)
         print("Wrote", fileName)
         pnum += 1
 

--- a/tests/testLoadAstrometryNetObjects.py
+++ b/tests/testLoadAstrometryNetObjects.py
@@ -35,6 +35,8 @@ from lsst.afw.table import CoordKey, Point2DKey
 from lsst.meas.astrom import LoadAstrometryNetObjectsTask, AstrometryNetDataConfig
 from testFindAstrometryNetDataDir import setupAstrometryNetDataDir
 
+DoPlot = False
+
 
 class TestLoadAstrometryNetObjects(unittest.TestCase):
 
@@ -76,7 +78,8 @@ class TestLoadAstrometryNetObjects(unittest.TestCase):
 
         loadRes = loadANetObj.loadPixelBox(bbox=self.bbox, wcs=self.wcs, filterName="r")
         refCat = loadRes.refCat
-#        self.plotStars(refCat, bbox=self.bbox)
+        if DoPlot:
+            self.plotStars(refCat, bbox=self.bbox)
         self.assertEqual(loadRes.fluxField, "r_flux")
         self.assertEqual(len(refCat), self.desNumStarsInPixelBox)
         self.assertObjInBBox(refCat=refCat, bbox=self.bbox, wcs=self.wcs)
@@ -189,18 +192,18 @@ class TestLoadAstrometryNetObjects(unittest.TestCase):
     def plotStars(self, refCat, bbox=None):
         """Plot the centroids of reference objects, and the bounding box (if specified)
         """
-        import matplotlib.pyplot as pyplot
+        import matplotlib.pyplot as plt
         if bbox is not None:
             cornerList = list(afwGeom.Box2D(bbox).getCorners())
             cornerList.append(cornerList[0])  # show 4 sides of the box by going back to the beginning
             xc, yc = list(zip(*cornerList))
-            pyplot.plot(xc, yc, '-')
+            plt.plot(xc, yc, '-')
 
-        centroidKey = refCat.schema["centroid"].asKey()
+        centroidKey = Point2DKey(refCat.schema["centroid"])
         centroidList = [rec.get(centroidKey) for rec in refCat]
         xp, yp = list(zip(*centroidList))
-        pyplot.plot(xp, yp, '.')
-        pyplot.show()
+        plt.plot(xp, yp, '.')
+        plt.show()
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Some tests and one bit of library code were importing matplotlib
even if plotting was not requested. This could cause needless failures
(not to mention unwanted rebuilds of the font cache).
I standardized on only importing when plotting is specifically requested,
and the library code prints an error message and continues
(whereas the unit tests fail, a safe thing to do because they
do not normally plot anyway).