### PR TITLE
tickets/DM-9120: matcherSourceSelector incorrectly uses nChild and footprints in isMultiple test.

### DIFF
--- a/tests/testAstrometryTask.py
+++ b/tests/testAstrometryTask.py
@@ -152,8 +152,6 @@ class TestAstrometricSolver(lsst.utils.tests.TestCase):
         refFluxRKey = refCat.schema["r_flux"].asKey()
 
         sourceSchema = afwTable.SourceTable.makeMinimalSchema()
-        # deblend_nChild is required by matcherSourceSelector used in matchOptimisticB.py
-        sourceDeblendNChild = sourceSchema.addField("deblend_nChild", type=int)
         measBase.SingleFrameMeasurementTask(schema=sourceSchema)  # expand the schema
         sourceCat = afwTable.SourceCatalog(sourceSchema)
         sourceCentroidKey = afwTable.Point2DKey(sourceSchema["slot_Centroid"])
@@ -165,7 +163,6 @@ class TestAstrometricSolver(lsst.utils.tests.TestCase):
             src.set(sourceCentroidKey, refObj.get(refCentroidKey))
             src.set(sourceFluxKey, refObj.get(refFluxRKey))
             src.set(sourceFluxSigmaKey, refObj.get(refFluxRKey)/100)
-            src.set(sourceDeblendNChild, 0)
         return sourceCat
 
 

--- a/tests/testJoinMatchListWithCatalog.py
+++ b/tests/testJoinMatchListWithCatalog.py
@@ -42,9 +42,6 @@ class joinMatchListWithCatalogTestCase(unittest.TestCase):
         testDir = os.path.dirname(__file__)
 
         self.srcSet = SourceCatalog.readFits(os.path.join(testDir, "v695833-e0-c000.xy.fits"))
-        aliasMap = self.srcSet.schema.getAliasMap()
-        # deblend_nChild is required by matcherSourceSelector used in matchOptimisticB.py
-        aliasMap.set("deblend_nChild", "parent")
 
         self.bbox = afwGeom.Box2I(afwGeom.Point2I(0, 0), afwGeom.Extent2I(2048, 4612))  # approximate
         # create an exposure with the right metadata; the closest thing we have is

--- a/tests/testMatchOptimisticB.py
+++ b/tests/testMatchOptimisticB.py
@@ -177,12 +177,8 @@ class TestMatchOptimisticB(unittest.TestCase):
         sourceCat = afwTable.SourceCatalog.readFits(filename)
         aliasMap = sourceCat.schema.getAliasMap()
         aliasMap.set("slot_ApFlux", "base_PsfFlux")
-        # This is a kludge to create and force the deblend_nChild column to be set to 0.
-        # deblend_nChild is required by the sourceSelectors used by matchOptimisticB.
-        aliasMap.set("deblend_nChild", "parent")
         fluxKey = sourceCat.schema["slot_ApFlux_flux"].asKey()
         fluxSigmaKey = sourceCat.schema["slot_ApFlux_fluxSigma"].asKey()
-        nChildKey = sourceCat.schema["deblend_nChild"].asKey()
 
         # print("schema=", sourceCat.schema)
 
@@ -193,7 +189,6 @@ class TestMatchOptimisticB(unittest.TestCase):
             src.set(centroidKey, adjCentroid)
             src.set(fluxKey, 1000)
             src.set(fluxSigmaKey, 1)
-            src.set(nChildKey, 0)
 
         # Set catalog coord
         for src in sourceCat:


### PR DESCRIPTION
Removed test requirements for the variable nChild.