### PR TITLE
DM-4639: modernize afw code and reduce doxygen errors

### DIFF
--- a/src/sip/CreateWcsWithSip.cc
+++ b/src/sip/CreateWcsWithSip.cc
@@ -252,7 +252,7 @@ CreateWcsWithSip<MatchT>::_calculateForwardMatrices()
 
     afwGeom::Point2D crval = _getCrvalAsGeomPoint();
 
-    _linearWcs = afwImg::Wcs::Ptr( new afwImg::Wcs(crval, crpix, CD));
+    _linearWcs = std::shared_ptr<afwImg::Wcs>( new afwImg::Wcs(crval, crpix, CD));
 
     //Get Sip terms
     


### PR DESCRIPTION
[DM-4639](https://jira.lsstcorp.org/browse/DM-4639) requires that `afw` components no longer have type members `Ptr` and `ConstPtr` representing shared pointers to those types. This is a breaking API change that requires changes to downstream code.

For clarity, no unnecessary changes changes were made to this package, not even a `clang-format` pass.