### PR TITLE
DM-9751: Verify the performance of new matchPessimisticB code on selected test fields

### DIFF
--- a/python/lsst/meas/astrom/matchPessimisticB.py
+++ b/python/lsst/meas/astrom/matchPessimisticB.py
@@ -559,7 +559,7 @@ class MatchPessimisticBTask(pipeBase.Task):
         else:
             hold_cut = input_cut
         # Start clipping
-        for clip_idx in xrange(100):
+        for clip_idx in range(100):
             # Find the mask and current total objects.
             mask = (values < hold_cut)
             total = len(values[mask])

--- a/tests/test_MatchPessimisticB.py
+++ b/tests/test_MatchPessimisticB.py
@@ -36,7 +36,7 @@ import lsst.meas.astrom.sip.genDistortedImage as distort
 import lsst.meas.astrom as measAstrom
 
 
-class TestMatchOptimisticB(unittest.TestCase):
+class TestMatchPessimisticB(unittest.TestCase):
 
     def setUp(self):
 
@@ -91,7 +91,6 @@ class TestMatchOptimisticB(unittest.TestCase):
         self.distortedWcs = afwImage.DistortedTanWcs(
             self.wcs, pixelsToTanPixels)
 
-
         def applyDistortion(src):
             out = src.table.copyRecord(src)
             out.set(out.table.getCentroidKey(),
@@ -137,11 +136,7 @@ class TestMatchOptimisticB(unittest.TestCase):
         if doPlot:
             measAstrom.plotAstrometry(matches=matches, refCat=refCat,
                                       sourceCat=sourceCat)
-        if distortFunc == distort.quadraticDistort:
-            # Quad distort finds 181 real matches for Pessimistic
-            self.assertEqual(len(matches), 184)
-        else:
-            self.assertEqual(len(matches), 186)
+        self.assertEqual(len(matches), 183)
 
         refCoordKey = afwTable.CoordKey(refCat.schema["coord"])
         srcCoordKey = afwTable.CoordKey(sourceCat.schema["coord"])
@@ -155,9 +150,7 @@ class TestMatchOptimisticB(unittest.TestCase):
             distErr = abs(predDist - distRad*afwGeom.radians)
             maxDistErr = max(distErr, maxDistErr)
 
-            # Current skip refObj 15 as it matches to source 12.
-            # All other matches are correct.
-            if refObj.getId() != source.getId() and refObj.getId() != 15:
+            if refObj.getId() != source.getId():
                 refCentroid = refObj.get(refCentroidKey)
                 sourceCentroid = source.getCentroid()
                 radius = math.hypot(*(refCentroid - sourceCentroid))

--- a/tests/test_PessimisticPatternMatcherB3D.py
+++ b/tests/test_PessimisticPatternMatcherB3D.py
@@ -119,10 +119,10 @@ class TestPessimisticPatternMatcherB(unittest.TestCase):
             source_array=self.source_obj_array, n_check=9, n_match=6,
             n_agree=2, max_n_patterns=100, max_shift=60., max_rotation=5.0,
             max_dist=5., min_matches=30, pattern_skip_array=None)
-        self.assertEqual(len(match_struct.matches),
+        self.assertEqual(len(match_struct.match_ids),
                          len(self.reference_obj_array))
         self.assertTrue(
-            np.all(match_struct.distances < 0.01/3600.0 * __deg_to_rad__))
+            np.all(match_struct.distances_rad < 0.01/3600.0 * __deg_to_rad__))
 
     def testOptimisticMatch(self):
         """ Test the optimistic mode of the pattern matcher. That is
@@ -137,10 +137,10 @@ class TestPessimisticPatternMatcherB(unittest.TestCase):
             source_array=self.source_obj_array, n_check=9, n_match=6,
             n_agree=1, max_n_patterns=100, max_shift=60., max_rotation=6.0,
             max_dist=5., min_matches=30, pattern_skip_array=None)
-        self.assertEqual(len(match_struct.matches),
+        self.assertEqual(len(match_struct.match_ids),
                          len(self.reference_obj_array))
         self.assertTrue(
-            np.all(match_struct.distances < 0.01/3600.0 * __deg_to_rad__))
+            np.all(match_struct.distances_rad < 0.01/3600.0 * __deg_to_rad__))
 
     def testMatchSkip(self):
         """ Test the ablity to skip specified patterns in the matching
@@ -154,10 +154,10 @@ class TestPessimisticPatternMatcherB(unittest.TestCase):
             source_array=self.source_obj_array, n_check=9, n_match=6,
             n_agree=2, max_n_patterns=100, max_shift=60., max_rotation=5.0,
             max_dist=5., min_matches=30, pattern_skip_array=np.array([0]))
-        self.assertEqual(len(match_struct.matches),
+        self.assertEqual(len(match_struct.match_ids),
                          len(self.reference_obj_array))
         self.assertTrue(
-            np.all(match_struct.distances < 0.01/3600.0 * __deg_to_rad__))
+            np.all(match_struct.distances_rad < 0.01/3600.0 * __deg_to_rad__))
 
     def testMatchMoreSources(self):
         """ Test the case where we have more sources than references
@@ -171,10 +171,10 @@ class TestPessimisticPatternMatcherB(unittest.TestCase):
             source_array=self.source_obj_array, n_check=9, n_match=6,
             n_agree=2, max_n_patterns=100, max_shift=60.0, max_rotation=5.0,
             max_dist=5., min_matches=30, pattern_skip_array=None)
-        self.assertEqual(len(match_struct.matches),
+        self.assertEqual(len(match_struct.match_ids),
                          len(self.reference_obj_array[:500]))
         self.assertTrue(
-            np.all(match_struct.distances < 0.01/3600.0 * __deg_to_rad__))
+            np.all(match_struct.distances_rad < 0.01/3600.0 * __deg_to_rad__))
 
     def testMatchMoreReferences(self):
         """ Test the case where we have more references than sources
@@ -188,10 +188,10 @@ class TestPessimisticPatternMatcherB(unittest.TestCase):
             source_array=self.source_obj_array[:500], n_check=9, n_match=6,
             n_agree=2, max_n_patterns=100, max_shift=60., max_rotation=1.0,
             max_dist=5., min_matches=30, pattern_skip_array=None)
-        self.assertEqual(len(match_struct.matches),
+        self.assertEqual(len(match_struct.match_ids),
                          len(self.reference_obj_array[:500]))
         self.assertTrue(
-            np.all(match_struct.distances < 0.01/3600.0 * __deg_to_rad__))
+            np.all(match_struct.distances_rad < 0.01/3600.0 * __deg_to_rad__))
 
     def testShift(self):
         """ Test the matcher when a shift is applied to the data.
@@ -217,10 +217,10 @@ class TestPessimisticPatternMatcherB(unittest.TestCase):
             n_agree=2, max_n_patterns=100, max_shift=60, max_rotation=5.0,
             max_dist=5., min_matches=30, pattern_skip_array=None)
 
-        self.assertEqual(len(match_struct.matches),
+        self.assertEqual(len(match_struct.match_ids),
                          len(self.reference_obj_array))
         self.assertTrue(
-            np.all(match_struct.distances < 0.01/3600.0 * __deg_to_rad__))
+            np.all(match_struct.distances_rad < 0.01/3600.0 * __deg_to_rad__))
 
     def testRotation(self):
         """ Test the matcher for when a roation is applied to the data.
@@ -242,10 +242,10 @@ class TestPessimisticPatternMatcherB(unittest.TestCase):
             n_agree=2, max_n_patterns=100, max_shift=60, max_rotation=5.0,
             max_dist=5., min_matches=30, pattern_skip_array=None)
 
-        self.assertEqual(len(match_struct.matches),
+        self.assertEqual(len(match_struct.match_ids),
                          len(self.reference_obj_array))
         self.assertTrue(
-            np.all(match_struct.distances < 0.01/3600.0 * __deg_to_rad__))
+            np.all(match_struct.distances_rad < 0.01/3600.0 * __deg_to_rad__))
 
     def testShiftRotation(self):
         """ Test both a shift and rotation being applied to the data.
@@ -276,10 +276,10 @@ class TestPessimisticPatternMatcherB(unittest.TestCase):
             n_agree=2, max_n_patterns=100, max_shift=60., max_rotation=5.0,
             max_dist=5., min_matches=30, pattern_skip_array=None)
 
-        self.assertEqual(len(match_struct.matches),
+        self.assertEqual(len(match_struct.match_ids),
                          len(self.reference_obj_array))
         self.assertTrue(
-            np.all(match_struct.distances < 0.01/3600.0 * __deg_to_rad__))
+            np.all(match_struct.distances_rad < 0.01/3600.0 * __deg_to_rad__))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Several stability improvements also made to matcher during this verification.

matchPessimisticB.py: Reordered cut calculations for clarity. Changed first matcher iteration to only use optimistic mode only after a match has been found on a previous match/fit iteration. Changed cut on match distance to be a 2 sigma clip instead of a hard cut.
pessimistic_pattern_matcher_b_3D.py: Added least squares fit to shift and rotation matrix in intermediate verify. removed distance cut from final verify. This cut is now done in matchPessimisticB.

Removed max_dist from _match_sources method.

Linter pass and editted sigma clip start.