### PR TITLE
DM-8828: Support proper motions in reference catalogs

### DIFF
--- a/python/lsst/meas/astrom/astrometry.py
+++ b/python/lsst/meas/astrom/astrometry.py
@@ -210,12 +210,14 @@ class AstrometryTask(RefMatchTask):
             wcs=expMd.wcs,
             filterName=expMd.filterName,
             calib=expMd.calib,
+            epoch=expMd.epoch,
         )
         matchMeta = self.refObjLoader.getMetadataBox(
             bbox=expMd.bbox,
             wcs=expMd.wcs,
             filterName=expMd.filterName,
             calib=expMd.calib,
+            epoch=expMd.epoch,
         )
 
         if debug.display:

--- a/python/lsst/meas/astrom/directMatch.py
+++ b/python/lsst/meas/astrom/directMatch.py
@@ -91,22 +91,24 @@ class DirectMatchTask(Task):
         self.makeSubtask("sourceSelection")
         self.makeSubtask("referenceSelection")
 
-    def run(self, catalog, filterName=None):
+    def run(self, catalog, filterName=None, epoch=None):
         """!Load reference objects and match to them
 
         @param[in] catalog  Catalog to match to (lsst.afw.table.SourceCatalog)
         @param[in] filterName  Name of filter, for loading fluxes (str)
+        @param[in] epoch  Epoch for proper motion and parallax correction
+                          (an astropy.time.Time), or None
         @return Struct with matches (lsst.afw.table.SourceMatchVector) and
             matchMeta (lsst.meas.astrom.MatchMetadata)
         """
         circle = self.calculateCircle(catalog)
-        matchMeta = self.refObjLoader.getMetadataCircle(circle.center, circle.radius, filterName)
+        matchMeta = self.refObjLoader.getMetadataCircle(circle.center, circle.radius, filterName, epoch=epoch)
         emptyResult = Struct(matches=[], matchMeta=matchMeta)
         sourceSelection = self.sourceSelection.run(catalog)
         if len(sourceSelection.sourceCat) == 0:
             self.log.warn("No objects selected from %d objects in source catalog", len(catalog))
             return emptyResult
-        refData = self.refObjLoader.loadSkyCircle(circle.center, circle.radius, filterName)
+        refData = self.refObjLoader.loadSkyCircle(circle.center, circle.radius, filterName, epoch=epoch)
         refCat = refData.refCat
         refSelection = self.referenceSelection.run(refCat)
         if len(refSelection.sourceCat) == 0:


### PR DESCRIPTION
Mainly this consists of getting the epoch (TAI MJD) of the exposure into
the catalog loader.