### PR TITLE
DM-14842: Fix deprecation warnings from PropertyList/Set.get

### DIFF
--- a/examples/getSourceSet.py
+++ b/examples/getSourceSet.py
@@ -247,8 +247,8 @@ def makeCcdMosaic(dir, basename, e, c, aList, imageFactory=afwImage.MaskedImageF
 
             if what == "header":
                 md = readMetadata(filename + "_img.fits")
-                xy0 = lsst.geom.Point2I(md.get("CRVAL1A"), md.get("CRVAL2A"))
-                xy1 = xy0 + lsst.geom.Extent2I(md.get("NAXIS1") - 1, md.get("NAXIS2") - 1)
+                xy0 = lsst.geom.Point2I(md.getScalar("CRVAL1A"), md.getScalar("CRVAL2A"))
+                xy1 = xy0 + lsst.geom.Extent2I(md.getScalar("NAXIS1") - 1, md.getScalar("NAXIS2") - 1)
                 bbox.grow(xy0)
                 bbox.grow(xy1)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -307,12 +307,12 @@ class SipForwardTransformTestCase(lsst.utils.tests.TestCase, TransformTestMixin)
         # so ignore the RADESYS in metadata (which is missing anyway, falling back to FK5)
         sipMetadata.set("RADESYS", "ICRS")
         crpix = lsst.afw.geom.Point2D(
-            sipMetadata.get("CRPIX1") - 1,
-            sipMetadata.get("CRPIX2") - 1,
+            sipMetadata.getScalar("CRPIX1") - 1,
+            sipMetadata.getScalar("CRPIX2") - 1,
         )
         crval = lsst.afw.geom.SpherePoint(
-            sipMetadata.get("CRVAL1"),
-            sipMetadata.get("CRVAL2"), lsst.afw.geom.degrees,
+            sipMetadata.getScalar("CRVAL1"),
+            sipMetadata.getScalar("CRVAL2"), lsst.afw.geom.degrees,
         )
         cdLinearTransform = lsst.afw.geom.LinearTransform(getCdMatrixFromMetadata(sipMetadata))
         aArr = getSipMatrixFromMetadata(sipMetadata, "A")


### PR DESCRIPTION
Use `getScalar` or `getArray` instead of deprecated `get`
on `PropertySet` and `PropertyList` instances.