### PR TITLE
DM-18314: reduce namespace confusion for matchOptimisticB

### DIFF
--- a/python/lsst/meas/astrom/__init__.py
+++ b/python/lsst/meas/astrom/__init__.py
@@ -21,7 +21,7 @@
 #
 
 from .makeMatchStatistics import *
-from .matchOptimisticB import *
+from .matchOptimisticBTask import *
 from .polynomialTransform import *
 from .scaledPolynomialTransformFitter import *
 from .sipTransform import *
@@ -31,7 +31,6 @@ from . import sip
 from .ref_match import *
 from .astrometry import *
 from .approximateWcs import *
-from .matchOptimisticB import *
 from .matchPessimisticB import *
 from .setMatchDistance import *
 from .display import *

--- a/python/lsst/meas/astrom/matchOptimisticB/__init__.py
+++ b/python/lsst/meas/astrom/matchOptimisticB/__init__.py
@@ -1,3 +1,2 @@
 
 from .matchOptimisticB import *
-from .matchOptimisticBContinued import *

--- a/python/lsst/meas/astrom/matchOptimisticBTask.py
+++ b/python/lsst/meas/astrom/matchOptimisticBTask.py
@@ -1,5 +1,5 @@
 
-__all__ = ["matchOptimisticB", "MatchOptimisticBTask", "MatchOptimisticBConfig",
+__all__ = ["MatchOptimisticBTask", "MatchOptimisticBConfig",
            "MatchTolerance"]
 
 import math
@@ -8,8 +8,8 @@ import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.meas.algorithms.sourceSelector import sourceSelectorRegistry
 
-from ..setMatchDistance import setMatchDistance
-from . import matchOptimisticB, MatchOptimisticBControl
+from .setMatchDistance import setMatchDistance
+from .matchOptimisticB import matchOptimisticB, MatchOptimisticBControl
 
 
 class MatchTolerance:

--- a/python/lsst/meas/astrom/matchPessimisticB.py
+++ b/python/lsst/meas/astrom/matchPessimisticB.py
@@ -9,7 +9,7 @@ import lsst.afw.geom as afwgeom
 import lsst.afw.table as afwTable
 from lsst.meas.algorithms.sourceSelector import sourceSelectorRegistry
 
-from .matchOptimisticB import MatchTolerance
+from .matchOptimisticBTask import MatchTolerance
 
 from .pessimistic_pattern_matcher_b_3D import PessimisticPatternMatcherB
 

--- a/src/sip/CreateWcsWithSip.cc
+++ b/src/sip/CreateWcsWithSip.cc
@@ -142,7 +142,7 @@ CreateWcsWithSip<MatchT>::CreateWcsWithSip(std::vector<MatchT> const& matches,
      * If no BBox is provided, guess one from the input points (extrapolated a bit to allow for fact
      * that a finite number of points won't reach to the edge of the image)
      */
-    if (_bbox.isEmpty() && !_matches.empty() > 0) {
+    if (_bbox.isEmpty() && !_matches.empty()) {
         for (typename std::vector<MatchT>::const_iterator ptr = _matches.begin(); ptr != _matches.end();
              ++ptr) {
             afw::table::SourceRecord const& src = *ptr->second;

--- a/tests/test_matchOptimisticB.py
+++ b/tests/test_matchOptimisticB.py
@@ -23,6 +23,7 @@
 import math
 import os
 import unittest
+import pickle
 
 import lsst.geom
 import lsst.afw.geom as afwGeom
@@ -32,6 +33,7 @@ import lsst.pex.exceptions as pexExcept
 from lsst.meas.algorithms import LoadReferenceObjectsTask
 import lsst.meas.astrom.sip.genDistortedImage as distort
 import lsst.meas.astrom as measAstrom
+import lsst.meas.astrom.matchOptimisticB as matchOptimisticB
 
 
 class TestMatchOptimisticB(unittest.TestCase):
@@ -179,7 +181,7 @@ class TestMatchOptimisticB(unittest.TestCase):
     def testArgumentErrors(self):
         """Test argument sanity checking in matchOptimisticB
         """
-        matchControl = measAstrom.MatchOptimisticBControl()
+        matchControl = matchOptimisticB.MatchOptimisticBControl()
 
         sourceCat = self.loadSourceCatalog(self.filename)
         emptySourceCat = afwTable.SourceCatalog(sourceCat.schema)
@@ -188,7 +190,7 @@ class TestMatchOptimisticB(unittest.TestCase):
         emptyRefCat = afwTable.SimpleCatalog(refCat.schema)
 
         with self.assertRaises(pexExcept.InvalidParameterError):
-            measAstrom.matchOptimisticB(
+            matchOptimisticB.matchOptimisticB(
                 emptyRefCat,
                 sourceCat,
                 matchControl,
@@ -196,7 +198,7 @@ class TestMatchOptimisticB(unittest.TestCase):
                 0,
             )
         with self.assertRaises(pexExcept.InvalidParameterError):
-            measAstrom.matchOptimisticB(
+            matchOptimisticB.matchOptimisticB(
                 refCat,
                 emptySourceCat,
                 matchControl,
@@ -204,7 +206,7 @@ class TestMatchOptimisticB(unittest.TestCase):
                 0,
             )
         with self.assertRaises(pexExcept.InvalidParameterError):
-            measAstrom.matchOptimisticB(
+            matchOptimisticB.matchOptimisticB(
                 refCat,
                 sourceCat,
                 matchControl,
@@ -212,13 +214,22 @@ class TestMatchOptimisticB(unittest.TestCase):
                 len(refCat),
             )
         with self.assertRaises(pexExcept.InvalidParameterError):
-            measAstrom.matchOptimisticB(
+            matchOptimisticB.matchOptimisticB(
                 refCat,
                 sourceCat,
                 matchControl,
                 self.wcs,
                 -1,
             )
+
+    def testConfigPickle(self):
+        """Test that we can pickle the Config
+
+        This is required for use in singleFrameDriver.
+        See DM-18314.
+        """
+        config = pickle.loads(pickle.dumps(self.config))
+        self.assertEqual(config, self.config)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
The 'matchOptimisticB' namespace is overloaded, which makes it
impossible to do:
    import lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued
    lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask
results in:
    AttributeError: 'builtin_function_or_method' object has no attribute 'matchOptimisticBContinued'

The 'matchOptimisticB' module contains a function called
'matchOptimisticB' which is being imported over the top of the
module, so rename that function. Move the MatchOptimisticBTask
from the 'matchOptimisticB' module so it can be accessed
without problems. Added a test that detects the problem.