### PR TITLE
DM-18372: Update MatchOptimisticBTask documentation

### DIFF
--- a/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask.rst
+++ b/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask.rst
@@ -1,4 +1,4 @@
-.. lsst-task-topic:: lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask
+.. lsst-task-topic:: lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask
 
 ####################
 MatchOptimisticBTask
@@ -12,7 +12,7 @@ as a preliminary step to fitting an astrometric or photometric solution.
 
 Optimistic Pattern Matching is described in [Tabur2007]_
 
-.. _lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask-summary:
+.. _lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask-summary:
 
 Processing summary
 ==================
@@ -30,28 +30,28 @@ Processing summary
   saturated.
 - Return these sources matched to the references.
 
-.. _lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask-api:
+.. _lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask-api:
 
 Python API summary
 ==================
 
-.. lsst-task-api-summary:: lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask
+.. lsst-task-api-summary:: lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask
 
-.. _lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask-subtasks:
+.. _lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask-subtasks:
 
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask
+.. lsst-task-config-subtasks:: lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask
 
-.. _lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask-configs:
+.. _lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask
+.. lsst-task-config-fields:: lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask
 
-.. _lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask-examples:
+.. _lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask-examples:
 
 Examples
 ========
@@ -67,7 +67,7 @@ PhotoCalTask.
 See :lsst-task:`lsst.pipe.tasks.photoCal.PhotoCalTask`
 .. note:: Pipe task will require conversion before this link is useable.
 
-.. _lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask-debug:
+.. _lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask-debug:
 
 Debugging
 =========

--- a/python/lsst/meas/astrom/directMatch.py
+++ b/python/lsst/meas/astrom/directMatch.py
@@ -10,8 +10,9 @@ from lsst.afw.geom import arcseconds, averageSpherePoint
 
 
 class DirectMatchConfigWithoutLoader(Config):
-    """Configuration for DirectMatchTask when an already-initialized
-    refObjLoader will be passed to this task."""
+    """Configuration for `DirectMatchTask` when an already-initialized
+    ``refObjLoader`` will be passed to this task.
+    """
     matchRadius = Field(dtype=float, default=0.25, doc="Matching radius, arcsec")
     sourceSelection = ConfigurableField(target=ScienceSourceSelectorTask,
                                         doc="Selection of science sources")
@@ -20,7 +21,8 @@ class DirectMatchConfigWithoutLoader(Config):
 
 
 class DirectMatchConfig(DirectMatchConfigWithoutLoader):
-    """Configuration for DirectMatchTask"""
+    """Configuration for `DirectMatchTask`.
+    """
     refObjLoader = ConfigurableField(target=LoadIndexedReferenceObjectsTask, doc="Load reference objects")
 
 
@@ -32,9 +34,10 @@ class DirectMatchTask(Task):
     butler : `lsst.daf.persistence.Butler`
         Data butler containing the relevant reference catalog data.
     refObjLoader : `lsst.meas.algorithms.LoadReferenceObjectsTask` or `None`
-        For loading reference objects
-    **kwargs :
-        Other keyword arguments required for instantiating a Task (e.g., 'config')
+        For loading reference objects.
+    **kwargs
+        Other keyword arguments required for instantiating a Task (such as
+        ``config``).
     """
     ConfigClass = DirectMatchConfig
     _DefaultName = "directMatch"
@@ -56,7 +59,7 @@ class DirectMatchTask(Task):
         self.makeSubtask("referenceSelection")
 
     def setRefObjLoader(self, refObjLoader):
-        """Sets the reference object loader for the task
+        """Set the reference object loader for the task.
 
         Parameters
         ----------
@@ -78,19 +81,21 @@ class DirectMatchTask(Task):
         catalog : `lsst.afw.table.SourceCatalog`
             Catalog to match.
         filterName : `str`
-            Name of filter loading fluxes
+            Name of filter loading fluxes.
         epoch : `astropy.time.Time` or `None`
-            Epoch to which to correct proper motion and parallax,
-            or `None` to not apply such corrections.
+            Epoch to which to correct proper motion and parallax, or `None` to
+            not apply such corrections.
 
         Returns
         -------
         result : `lsst.pipe.base.Struct`
             Result struct with components:
 
-            - matches : Matched sources with associated reference
-              (`lsst.afw.table.SourceMatchVector`)
-            - matchMeta : Match metadata (`lsst.meas.astrom.MatchMetadata`)
+            ``matches``
+                Matched sources with associated reference
+                (`lsst.afw.table.SourceMatchVector`).
+            ``matchMeta``
+                Match metadata (`lsst.meas.astrom.MatchMetadata`).
         """
         if self.refObjLoader is None:
             raise RuntimeError("Running matcher task with no refObjLoader set in __ini__ or setRefObjLoader")
@@ -116,20 +121,22 @@ class DirectMatchTask(Task):
                       refSelection=refSelection)
 
     def calculateCircle(self, catalog):
-        """Calculate a circle enclosing the catalog
+        """Calculate a circle enclosing the catalog.
 
         Parameters
         ----------
         catalog : `lsst.afw.table.SourceCatalog`
-            Catalog to encircle
+            Catalog to encircle.
 
         Returns
         -------
         result : `lsst.pipe.base.Struct`
             Result struct with components:
 
-            - center : ICRS center coordinate (`lsst.afw.geom.SpherePoint`)
-            - radius : Radius of the circle (`lsst.geom.Angle`)
+            ``center``
+                ICRS center coordinate (`lsst.afw.geom.SpherePoint`).
+            ``radius``
+                Radius of the circle (`lsst.geom.Angle`).
         """
         coordList = [src.getCoord() for src in catalog]
         center = averageSpherePoint(coordList)

--- a/python/lsst/meas/astrom/directMatch.py
+++ b/python/lsst/meas/astrom/directMatch.py
@@ -60,11 +60,13 @@ class DirectMatchTask(Task):
 
         Parameters
         ----------
-        refObjLoader : `lsst.meas.algorithms.LoadReferenceObjectsTask` or
-                       `lsst.meas.algorithms.ReferenceObjectLoader`
-            An instance of a reference object loader task or class. A task can be  used as a subtask
-            and is generally used in gen2 middleware. The class is designed to be used with gen3
-            middleware and is initialized outside the normal task framework.
+        refObjLoader
+            An instance of a reference object loader, either a
+            `lsst.meas.algorithms.LoadReferenceObjectsTask` task or a
+            `lsst.meas.algorithms.ReferenceObjectLoader` instance. A task can
+            be used as a subtask and is generally used in gen2 middleware. The
+            class is designed to be used with gen3 middleware and is
+            initialized outside the normal task framework.
         """
         self.refObjLoader = refObjLoader
 


### PR DESCRIPTION
This PR updates the task documentation for `MatchOptimisticBTask` to reflect its new location at `lsst.meas.astrom.matchOptimisticBTask`. This fixes a pipelines.lsst.io build failure.

Also introduces some micro docstring fixes to address warnings and syntax issues.