### PR TITLE
DM-18643: Add sourceSelection and refSelection to AstrometryTask.solve()

### DIFF
--- a/python/lsst/meas/astrom/astrometry.py
+++ b/python/lsst/meas/astrom/astrometry.py
@@ -171,6 +171,8 @@ class AstrometryTask(RefMatchTask):
 
         expMd = self._getExposureMetadata(exposure)
 
+        sourceSelection = self.sourceSelection.run(sourceCat)
+
         loadRes = self.refObjLoader.loadPixelBox(
             bbox=expMd.bbox,
             wcs=expMd.wcs,
@@ -178,6 +180,9 @@ class AstrometryTask(RefMatchTask):
             photoCalib=expMd.photoCalib,
             epoch=expMd.epoch,
         )
+
+        refSelection = self.referenceSelection.run(loadRes.refCat)
+
         matchMeta = self.refObjLoader.getMetadataBox(
             bbox=expMd.bbox,
             wcs=expMd.wcs,
@@ -189,8 +194,8 @@ class AstrometryTask(RefMatchTask):
         if debug.display:
             frame = int(debug.frame)
             displayAstrometry(
-                refCat=loadRes.refCat,
-                sourceCat=sourceCat,
+                refCat=refSelection.sourceCat,
+                sourceCat=sourceSelection.sourceCat,
                 exposure=exposure,
                 bbox=expMd.bbox,
                 frame=frame,
@@ -204,8 +209,8 @@ class AstrometryTask(RefMatchTask):
             iterNum = i + 1
             try:
                 tryRes = self._matchAndFitWcs(  # refCat, sourceCat, refFluxField, bbox, wcs, exposure=None
-                    refCat=loadRes.refCat,
-                    sourceCat=sourceCat,
+                    refCat=refSelection.sourceCat,
+                    sourceCat=sourceSelection.sourceCat,
                     refFluxField=loadRes.fluxField,
                     bbox=expMd.bbox,
                     wcs=wcs,
@@ -251,7 +256,7 @@ class AstrometryTask(RefMatchTask):
         exposure.setWcs(res.wcs)
 
         return pipeBase.Struct(
-            refCat=loadRes.refCat,
+            refCat=refSelection.sourceCat,
             matches=res.matches,
             scatterOnSky=res.scatterOnSky,
             matchMeta=matchMeta,

--- a/python/lsst/meas/astrom/ref_match.py
+++ b/python/lsst/meas/astrom/ref_match.py
@@ -67,9 +67,9 @@ class RefMatchConfig(pexConfig.Config):
         self.sourceSelector.name = "science"
         self.sourceSelector['science'].fluxLimit.fluxField = \
             'slot_%sFlux_instFlux' % (self.sourceFluxType)
-        self.sourceSelector['science'].signalToNoiseLimit.fluxField = \
+        self.sourceSelector['science'].signalToNoise.fluxField = \
             'slot_%sFlux_instFlux' % (self.sourceFluxType)
-        self.sourceSelector['science'].signalToNoiseLimit.errField = \
+        self.sourceSelector['science'].signalToNoise.errField = \
             'slot_%sFlux_instFluxErr' % (self.sourceFluxType)
 
 

--- a/python/lsst/meas/astrom/ref_match.py
+++ b/python/lsst/meas/astrom/ref_match.py
@@ -67,9 +67,9 @@ class RefMatchConfig(pexConfig.Config):
         self.sourceSelector.name = "science"
         self.sourceSelector['science'].fluxLimit.fluxField = \
             'slot_%sFlux_instFlux' % (self.sourceFluxType)
-        self.sourceSelector['science'].SignalToNoiseLimit.fluxField = \
+        self.sourceSelector['science'].signalToNoiseLimit.fluxField = \
             'slot_%sFlux_instFlux' % (self.sourceFluxType)
-        self.sourceSelector['science'].SignalToNoiseLimit.errField = \
+        self.sourceSelector['science'].signalToNoiseLimit.errField = \
             'slot_%sFlux_instFluxErr' % (self.sourceFluxType)
 
 

--- a/tests/test_joinMatchListWithCatalog.py
+++ b/tests/test_joinMatchListWithCatalog.py
@@ -62,7 +62,7 @@ class JoinMatchListWithCatalogTestCase(unittest.TestCase):
         self.astrom.log.setLevel(logLevel)
         # Since our sourceSelector is a registry object we have to wait for it to be created
         # before setting default values.
-        self.astrom.matcher.sourceSelector.config.minSnr = 0
+        self.astrom.sourceSelector.config.minSnr = 0
 
     def tearDown(self):
         del self.srcSet

--- a/tests/test_matchPessimisticB.py
+++ b/tests/test_matchPessimisticB.py
@@ -101,7 +101,13 @@ class TestMatchPessimisticB(unittest.TestCase):
     def singleTestInstance(self, filename, distortFunc, doPlot=False):
         sourceCat = self.loadSourceCatalog(self.filename)
         refCat = self.computePosRefCatalog(sourceCat)
-        distortedCat = distort.distortList(sourceCat, distortFunc)
+
+        # Apply source selector to sourceCat, using the astrometry config defaults
+        tempConfig = measAstrom.AstrometryTask.ConfigClass()
+        tempSolver = measAstrom.AstrometryTask(config=tempConfig, refObjLoader=None)
+        sourceSelection = tempSolver.sourceSelector.run(sourceCat)
+
+        distortedCat = distort.distortList(sourceSelection.sourceCat, distortFunc)
 
         if doPlot:
             import matplotlib.pyplot as plt
@@ -128,6 +134,7 @@ class TestMatchPessimisticB(unittest.TestCase):
             refCat=refCat,
             sourceCat=sourceCat,
             wcs=self.distortedWcs,
+            sourceFluxField='slot_ApFlux_instFlux',
             refFluxField="r_flux",
         )
         matches = matchRes.matches
@@ -165,7 +172,13 @@ class TestMatchPessimisticB(unittest.TestCase):
         """
         sourceCat = self.loadSourceCatalog(self.filename)
         refCat = self.computePosRefCatalog(sourceCat)
-        distortedCat = distort.distortList(sourceCat, distort.linearXDistort)
+
+        # Apply source selector to sourceCat, using the astrometry config defaults
+        tempConfig = measAstrom.AstrometryTask.ConfigClass()
+        tempSolver = measAstrom.AstrometryTask(config=tempConfig, refObjLoader=None)
+        sourceSelection = tempSolver.sourceSelector.run(sourceCat)
+
+        distortedCat = distort.distortList(sourceSelection.sourceCat, distort.linearXDistort)
 
         sourceCat = distortedCat
 
@@ -173,6 +186,7 @@ class TestMatchPessimisticB(unittest.TestCase):
             refCat=refCat,
             sourceCat=sourceCat,
             wcs=self.distortedWcs,
+            sourceFluxField='slot_ApFlux_instFlux',
             refFluxField="r_flux",
         )
 
@@ -192,6 +206,7 @@ class TestMatchPessimisticB(unittest.TestCase):
             refCat=refCat,
             sourceCat=sourceCat,
             wcs=self.distortedWcs,
+            sourceFluxField='slot_ApFlux_instFlux',
             refFluxField="r_flux",
             match_tolerance=matchTol,
         )
@@ -209,20 +224,27 @@ class TestMatchPessimisticB(unittest.TestCase):
         """Test sub-selecting reference objects by flux."""
         sourceCat = self.loadSourceCatalog(self.filename)
         refCat = self.computePosRefCatalog(sourceCat)
-        distortedCat = distort.distortList(sourceCat, distort.linearXDistort)
+
+        # Apply source selector to sourceCat, using the astrometry config defaults
+        tempConfig = measAstrom.AstrometryTask.ConfigClass()
+        tempSolver = measAstrom.AstrometryTask(config=tempConfig, refObjLoader=None)
+        sourceSelection = tempSolver.sourceSelector.run(sourceCat)
+
+        distortedCat = distort.distortList(sourceSelection.sourceCat, distort.linearXDistort)
 
         matchPessConfig = measAstrom.MatchPessimisticBTask.ConfigClass()
         matchPessConfig.maxRefObjects = 150
         matchPessConfig.minMatchDistPixels = 5.0
 
         matchPess = measAstrom.MatchPessimisticBTask(config=matchPessConfig)
-        trimedRefCat = matchPess._filterRefCat(refCat, 'r_flux')
-        self.assertEqual(len(trimedRefCat), matchPessConfig.maxRefObjects)
+        trimmedRefCat = matchPess._filterRefCat(refCat, 'r_flux')
+        self.assertEqual(len(trimmedRefCat), matchPessConfig.maxRefObjects)
 
         matchRes = matchPess.matchObjectsToSources(
             refCat=refCat,
             sourceCat=distortedCat,
             wcs=self.distortedWcs,
+            sourceFluxField='slot_ApFlux_instFlux',
             refFluxField="r_flux",
         )
 


### PR DESCRIPTION
Note that the default source and reference selectors (defined in
RefMatchConfig) do not down-select, so fixing this bug will not change the
default runs. However, anybody who thought they were doing source or
reference selection will see a change now that that is happening.