### PR TITLE
DM-18643: Move AstrometryTask source selection from "matcher" into AstrometryTask	

### DIFF
--- a/python/lsst/meas/astrom/astrometry.py
+++ b/python/lsst/meas/astrom/astrometry.py
@@ -171,6 +171,8 @@ class AstrometryTask(RefMatchTask):
 
         expMd = self._getExposureMetadata(exposure)
 
+        sourceSelection = self.sourceSelection.run(sourceCat)
+
         loadRes = self.refObjLoader.loadPixelBox(
             bbox=expMd.bbox,
             wcs=expMd.wcs,
@@ -178,6 +180,9 @@ class AstrometryTask(RefMatchTask):
             photoCalib=expMd.photoCalib,
             epoch=expMd.epoch,
         )
+
+        refSelection = self.referenceSelection.run(loadRes.refCat)
+
         matchMeta = self.refObjLoader.getMetadataBox(
             bbox=expMd.bbox,
             wcs=expMd.wcs,
@@ -189,8 +194,8 @@ class AstrometryTask(RefMatchTask):
         if debug.display:
             frame = int(debug.frame)
             displayAstrometry(
-                refCat=loadRes.refCat,
-                sourceCat=sourceCat,
+                refCat=refSelection.sourceCat,
+                sourceCat=sourceSelection.sourceCat,
                 exposure=exposure,
                 bbox=expMd.bbox,
                 frame=frame,
@@ -204,8 +209,8 @@ class AstrometryTask(RefMatchTask):
             iterNum = i + 1
             try:
                 tryRes = self._matchAndFitWcs(  # refCat, sourceCat, refFluxField, bbox, wcs, exposure=None
-                    refCat=loadRes.refCat,
-                    sourceCat=sourceCat,
+                    refCat=refSelection.sourceCat,
+                    sourceCat=sourceSelection.sourceCat,
                     refFluxField=loadRes.fluxField,
                     bbox=expMd.bbox,
                     wcs=wcs,
@@ -251,7 +256,7 @@ class AstrometryTask(RefMatchTask):
         exposure.setWcs(res.wcs)
 
         return pipeBase.Struct(
-            refCat=loadRes.refCat,
+            refCat=refSelection.sourceCat,
             matches=res.matches,
             scatterOnSky=res.scatterOnSky,
             matchMeta=matchMeta,

--- a/python/lsst/meas/astrom/ref_match.py
+++ b/python/lsst/meas/astrom/ref_match.py
@@ -29,7 +29,8 @@ from lsst.daf.base import DateTime
 import lsst.afw.math as afwMath
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
-from lsst.meas.algorithms import ScienceSourceSelectorTask, ReferenceSourceSelectorTask
+from lsst.meas.algorithms import ReferenceSourceSelectorTask
+from lsst.meas.algorithms.sourceSelector import sourceSelectorRegistry
 from .matchPessimisticB import MatchPessimisticBTask
 from .display import displayAstrometry
 from . import makeMatchStatistics
@@ -48,10 +49,28 @@ class RefMatchConfig(pexConfig.Config):
         default=2,
         min=0,
     )
-    sourceSelection = pexConfig.ConfigurableField(target=ScienceSourceSelectorTask,
-                                                  doc="Selection of science sources")
-    referenceSelection = pexConfig.ConfigurableField(target=ReferenceSourceSelectorTask,
-                                                     doc="Selection of reference sources")
+    sourceSelector = sourceSelectorRegistry.makeField(
+        doc="How to select sources for cross-matching.",
+        default="science",
+    )
+    referenceSelector = pexConfig.ConfigurableField(
+        target=ReferenceSourceSelectorTask,
+        doc="How to select reference objects for cross-matching."
+    )
+    sourceFluxType = pexConfig.Field(
+        dtype=str,
+        doc="Source flux type to use in source selection.",
+        default='Calib'
+    )
+
+    def setDefaults(self):
+        self.sourceSelector.name = "science"
+        self.sourceSelector['science'].fluxLimit.fluxField = \
+            'slot_%sFlux_instFlux' % (self.sourceFluxType)
+        self.sourceSelector['science'].signalToNoise.fluxField = \
+            'slot_%sFlux_instFlux' % (self.sourceFluxType)
+        self.sourceSelector['science'].signalToNoise.errField = \
+            'slot_%sFlux_instFluxErr' % (self.sourceFluxType)
 
 
 class RefMatchTask(pipeBase.Task):
@@ -73,9 +92,15 @@ class RefMatchTask(pipeBase.Task):
             self.refObjLoader = refObjLoader
         else:
             self.refObjLoader = None
+
+        if self.config.sourceSelector.name == 'matcher':
+            if self.config.sourceSelector['matcher'].sourceFluxType != self.config.sourceFluxType:
+                raise RuntimeError("The sourceFluxType in the sourceSelector['matcher'] must match "
+                                   "the configured sourceFluxType")
+
         self.makeSubtask("matcher")
-        self.makeSubtask("sourceSelection")
-        self.makeSubtask("referenceSelection")
+        self.makeSubtask("sourceSelector")
+        self.makeSubtask("referenceSelector")
 
     def setRefObjLoader(self, refObjLoader):
         """Sets the reference object loader for the task
@@ -122,7 +147,9 @@ class RefMatchTask(pipeBase.Task):
 
         expMd = self._getExposureMetadata(exposure)
 
-        sourceSelection = self.sourceSelection.run(sourceCat)
+        sourceSelection = self.sourceSelector.run(sourceCat)
+
+        sourceFluxField = "slot_%sFlux_instFlux" % (self.config.sourceFluxType)
 
         loadRes = self.refObjLoader.loadPixelBox(
             bbox=expMd.bbox,
@@ -131,7 +158,7 @@ class RefMatchTask(pipeBase.Task):
             photoCalib=expMd.photoCalib,
         )
 
-        refSelection = self.referenceSelection.run(loadRes.refCat)
+        refSelection = self.referenceSelector.run(loadRes.refCat)
 
         matchMeta = self.refObjLoader.getMetadataBox(
             bbox=expMd.bbox,
@@ -144,6 +171,7 @@ class RefMatchTask(pipeBase.Task):
             refCat=refSelection.sourceCat,
             sourceCat=sourceSelection.sourceCat,
             wcs=expMd.wcs,
+            sourceFluxField=sourceFluxField,
             refFluxField=loadRes.fluxField,
             match_tolerance=None,
         )

--- a/tests/test_joinMatchListWithCatalog.py
+++ b/tests/test_joinMatchListWithCatalog.py
@@ -62,7 +62,7 @@ class JoinMatchListWithCatalogTestCase(unittest.TestCase):
         self.astrom.log.setLevel(logLevel)
         # Since our sourceSelector is a registry object we have to wait for it to be created
         # before setting default values.
-        self.astrom.matcher.sourceSelector.config.minSnr = 0
+        self.astrom.sourceSelector.config.minSnr = 0
 
     def tearDown(self):
         del self.srcSet

--- a/tests/test_matchPessimisticB.py
+++ b/tests/test_matchPessimisticB.py
@@ -101,7 +101,13 @@ class TestMatchPessimisticB(unittest.TestCase):
     def singleTestInstance(self, filename, distortFunc, doPlot=False):
         sourceCat = self.loadSourceCatalog(self.filename)
         refCat = self.computePosRefCatalog(sourceCat)
-        distortedCat = distort.distortList(sourceCat, distortFunc)
+
+        # Apply source selector to sourceCat, using the astrometry config defaults
+        tempConfig = measAstrom.AstrometryTask.ConfigClass()
+        tempSolver = measAstrom.AstrometryTask(config=tempConfig, refObjLoader=None)
+        sourceSelection = tempSolver.sourceSelector.run(sourceCat)
+
+        distortedCat = distort.distortList(sourceSelection.sourceCat, distortFunc)
 
         if doPlot:
             import matplotlib.pyplot as plt
@@ -128,6 +134,7 @@ class TestMatchPessimisticB(unittest.TestCase):
             refCat=refCat,
             sourceCat=sourceCat,
             wcs=self.distortedWcs,
+            sourceFluxField='slot_ApFlux_instFlux',
             refFluxField="r_flux",
         )
         matches = matchRes.matches
@@ -165,7 +172,13 @@ class TestMatchPessimisticB(unittest.TestCase):
         """
         sourceCat = self.loadSourceCatalog(self.filename)
         refCat = self.computePosRefCatalog(sourceCat)
-        distortedCat = distort.distortList(sourceCat, distort.linearXDistort)
+
+        # Apply source selector to sourceCat, using the astrometry config defaults
+        tempConfig = measAstrom.AstrometryTask.ConfigClass()
+        tempSolver = measAstrom.AstrometryTask(config=tempConfig, refObjLoader=None)
+        sourceSelection = tempSolver.sourceSelector.run(sourceCat)
+
+        distortedCat = distort.distortList(sourceSelection.sourceCat, distort.linearXDistort)
 
         sourceCat = distortedCat
 
@@ -173,6 +186,7 @@ class TestMatchPessimisticB(unittest.TestCase):
             refCat=refCat,
             sourceCat=sourceCat,
             wcs=self.distortedWcs,
+            sourceFluxField='slot_ApFlux_instFlux',
             refFluxField="r_flux",
         )
 
@@ -192,6 +206,7 @@ class TestMatchPessimisticB(unittest.TestCase):
             refCat=refCat,
             sourceCat=sourceCat,
             wcs=self.distortedWcs,
+            sourceFluxField='slot_ApFlux_instFlux',
             refFluxField="r_flux",
             match_tolerance=matchTol,
         )
@@ -209,20 +224,27 @@ class TestMatchPessimisticB(unittest.TestCase):
         """Test sub-selecting reference objects by flux."""
         sourceCat = self.loadSourceCatalog(self.filename)
         refCat = self.computePosRefCatalog(sourceCat)
-        distortedCat = distort.distortList(sourceCat, distort.linearXDistort)
+
+        # Apply source selector to sourceCat, using the astrometry config defaults
+        tempConfig = measAstrom.AstrometryTask.ConfigClass()
+        tempSolver = measAstrom.AstrometryTask(config=tempConfig, refObjLoader=None)
+        sourceSelection = tempSolver.sourceSelector.run(sourceCat)
+
+        distortedCat = distort.distortList(sourceSelection.sourceCat, distort.linearXDistort)
 
         matchPessConfig = measAstrom.MatchPessimisticBTask.ConfigClass()
         matchPessConfig.maxRefObjects = 150
         matchPessConfig.minMatchDistPixels = 5.0
 
         matchPess = measAstrom.MatchPessimisticBTask(config=matchPessConfig)
-        trimedRefCat = matchPess._filterRefCat(refCat, 'r_flux')
-        self.assertEqual(len(trimedRefCat), matchPessConfig.maxRefObjects)
+        trimmedRefCat = matchPess._filterRefCat(refCat, 'r_flux')
+        self.assertEqual(len(trimmedRefCat), matchPessConfig.maxRefObjects)
 
         matchRes = matchPess.matchObjectsToSources(
             refCat=refCat,
             sourceCat=distortedCat,
             wcs=self.distortedWcs,
+            sourceFluxField='slot_ApFlux_instFlux',
             refFluxField="r_flux",
         )
 


### PR DESCRIPTION
Implementing RFC-589, this moves the source selector into the astrometry task, and additionally fixes the reference selector so it is run in both matching and solving modes.