### PR TITLE
DM-18293: Reduce FitTanSipWcs default order to 2.

### DIFF
--- a/python/lsst/meas/astrom/fitTanSipWcs.py
+++ b/python/lsst/meas/astrom/fitTanSipWcs.py
@@ -39,7 +39,7 @@ class FitTanSipWcsConfig(pexConfig.Config):
     order = pexConfig.RangeField(
         doc="order of SIP polynomial",
         dtype=int,
-        default=4,
+        default=2,
         min=0,
     )
     numIter = pexConfig.RangeField(


### PR DESCRIPTION
All maintained obs packages have overrides added or removed to maintain
original behavior. Lower order is more robust. See RFC-577