### PR TITLE
DM-27843: Add anyFilterMapsToThis support to ReferenceObjectLoader

### DIFF
--- a/python/lsst/meas/astrom/astrometry.py
+++ b/python/lsst/meas/astrom/astrometry.py
@@ -143,7 +143,6 @@ class AstrometryTask(RefMatchTask):
             The following are read only:
 
             - bbox
-            - photoCalib (may be absent)
             - filter (may be unset)
             - detector (if wcs is pure tangent; may be absent)
 
@@ -226,7 +225,6 @@ class AstrometryTask(RefMatchTask):
             bbox=expMd.bbox,
             wcs=expMd.wcs,
             filterName=expMd.filterName,
-            photoCalib=expMd.photoCalib,
             epoch=expMd.epoch,
         )
 
@@ -236,7 +234,6 @@ class AstrometryTask(RefMatchTask):
             bbox=expMd.bbox,
             wcs=expMd.wcs,
             filterName=expMd.filterName,
-            photoCalib=expMd.photoCalib,
             epoch=expMd.epoch,
         )
 

--- a/python/lsst/meas/astrom/ref_match.py
+++ b/python/lsst/meas/astrom/ref_match.py
@@ -156,7 +156,6 @@ class RefMatchTask(pipeBase.Task):
             bbox=expMd.bbox,
             wcs=expMd.wcs,
             filterName=expMd.filterName,
-            photoCalib=expMd.photoCalib,
             epoch=expMd.epoch,
         )
 
@@ -166,7 +165,6 @@ class RefMatchTask(pipeBase.Task):
             bbox=expMd.bbox,
             wcs=expMd.wcs,
             filterName=expMd.filterName,
-            photoCalib=expMd.photoCalib,
             epoch=expMd.epoch,
         )
 


### PR DESCRIPTION
I removed the long deprecated `photoCalib` arg from the gen3 code, and this is
the only place that passed it.