### PR TITLE
DM-27177: Deprecate transitional getFilterLabel API

### DIFF
--- a/python/lsst/meas/astrom/ref_match.py
+++ b/python/lsst/meas/astrom/ref_match.py
@@ -252,7 +252,7 @@ class RefMatchTask(pipeBase.Task):
 
         """
         exposureInfo = exposure.getInfo()
-        filterLabel = exposureInfo.getFilterLabel()
+        filterLabel = exposureInfo.getFilter()
         filterName = filterLabel.bandLabel if filterLabel is not None else None
         epoch = None
         if exposure.getInfo().hasVisitInfo():

--- a/tests/test_astrometryTask.py
+++ b/tests/test_astrometryTask.py
@@ -52,7 +52,7 @@ class TestAstrometricSolver(lsst.utils.tests.TestCase):
                                          cdMatrix=afwGeom.makeCdMatrix(scale=5.1e-5*lsst.geom.degrees))
         self.exposure = afwImage.ExposureF(self.bbox)
         self.exposure.setWcs(self.tanWcs)
-        self.exposure.setFilterLabel(afwImage.FilterLabel(band="r", physical="rTest"))
+        self.exposure.setFilter(afwImage.FilterLabel(band="r", physical="rTest"))
         filenames = sorted(glob.glob(os.path.join(refCatDir, 'ref_cats', 'cal_ref_cat', '??????.fits')))
         self.refObjLoader = MockReferenceObjectLoaderFromFiles(filenames, htmLevel=8)
 

--- a/tests/test_joinMatchListWithCatalog.py
+++ b/tests/test_joinMatchListWithCatalog.py
@@ -48,7 +48,7 @@ class JoinMatchListWithCatalogTestCase(unittest.TestCase):
         smallExposure = ExposureF(os.path.join(testDir, "v695833-e0-c000-a00.sci.fits"))
         self.exposure = ExposureF(self.bbox)
         self.exposure.setWcs(smallExposure.getWcs())
-        self.exposure.setFilterLabel(smallExposure.getFilterLabel())
+        self.exposure.setFilter(smallExposure.getFilter())
         # copy the pixels we can, in case the user wants a debug display
         mi = self.exposure.getMaskedImage()
         mi.assign(smallExposure.getMaskedImage(), smallExposure.getBBox())


### PR DESCRIPTION
This PR removes references to `getFilterLabel` and similarly-named methods, replacing them with `getFilter` (etc.) methods backed by `FilterLabel`.