### PR TITLE
Tickets/DM-32197: Cleanup lsstDebug references in Task docs

### DIFF
--- a/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.AstrometryTask.rst
+++ b/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.AstrometryTask.rst
@@ -45,29 +45,12 @@ Configuration fields
 
 .. lsst-task-config-fields:: lsst.meas.astrom.AstrometryTask
 
-.. _lsst.meas.astrom.AstrometryTask-examples:
-
-Examples
-========
-
-.. Add a brief example here.
-.. If there are multiple examples
-.. (such as one from a command-line context and another that uses the Python API)
-.. you can separate each example into a different subsection for clarity.
-
-See :lsst-task:`lsst.pipe.tasks.photoCal.PhotoCalTask`.
-
-.. note::
-
-   Task documentation is currently in the process of being converted from the old (Doxygen) system to this site.
-   Until that conversion is complete, refer to the `Doxygen documentation for PhotoCalTask <http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/classlsst_1_1pipe_1_1tasks_1_1photo_cal_1_1_photo_cal_task.html#PhotoCalTask_>`_.
-
 .. _lsst.meas.astrom.AstrometryTask-debug:
 
 Debugging
 =========
 
-The `lsst.pipe.base.cmdLineTask.CmdLineTask` command line task interface supports a flag -d to import debug.py from your PYTHONPATH; see `lsstDebug` for more about debug.py files.
+The `lsst.pipe.base.cmdLineTask.CmdLineTask` command line task interface supports a flag -d to import debug.py from your PYTHONPATH; see :ref:`lsstDebug` for more about debug.py files.
 
 The available variables in AstrometryTask are
 
@@ -90,4 +73,4 @@ To investigate the meas_astrom_astrometry_Debug, put something like
 
     lsstDebug.Info = DebugInfo
 
-into your debug.py file and run this task with the --debug flag.
+into your debug.py file and run this task with the ``--debug`` flag.

--- a/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.FitSipDistortion.rst
+++ b/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.FitSipDistortion.rst
@@ -89,7 +89,7 @@ Enabling DEBUG-level logging on this task will report the number of
 outliers rejected and the current estimate of intrinsic scatter at each
 iteration.
 
-FitSipDistortionTask also supports the following lsstDebug variables to
+FitSipDistortionTask also supports the following :ref:`lsstDebug` variables to
 control diagnostic displays:
 
 - FitSipDistortionTask.display: if True, enable display diagnostics.

--- a/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.MatchPessimisticBTask.rst
+++ b/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.MatchPessimisticBTask.rst
@@ -57,28 +57,12 @@ Configuration fields
 
 .. lsst-task-config-fields:: lsst.meas.astrom.MatchPessimisticBTask
 
-.. _lsst.meas.astrom.MatchPessimisticBTask-examples:
-
-Examples
-========
-
-.. Add a brief example here.
-.. If there are multiple examples
-.. (such as one from a command-line context and another that uses the Python API)
-.. you can separate each example into a different subsection for clarity.
-
-MatchPessimisticBTask is a subtask of AstrometryTask, which is called by
-PhotoCalTask.
-
-See :lsst-task:`lsst.pipe.tasks.photoCal.PhotoCalTask`
-.. note:: Pipe task will require conversion before this link is usable.
-
 .. _lsst.meas.astrom.MatchPessimisticBTask-debug:
 
 Debugging
 =========
 
-The `lsst.pipe.base.cmdLineTask.CmdLineTask` command line task interface supports a flag -d to import debug.py from your PYTHONPATH; see `lsstDebug` for more about debug.py files.
+The `lsst.pipe.base.cmdLineTask.CmdLineTask` command line task interface supports a flag -d to import debug.py from your PYTHONPATH; see :ref:`lsstDebug` for more about debug.py files.
 
 The available variables in MatchOptimisticB are
 
@@ -101,4 +85,4 @@ To investigate the meas_astrom_astrometry_Debug, put something like
 
     lsstDebug.Info = DebugInfo
 
-into your debug.py file and run this task with the --debug flag.
+into your debug.py file and run this task with the ``--debug`` flag.

--- a/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask.rst
+++ b/doc/lsst.meas.astrom/tasks/lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask.rst
@@ -51,28 +51,12 @@ Configuration fields
 
 .. lsst-task-config-fields:: lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask
 
-.. _lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask-examples:
-
-Examples
-========
-
-.. Add a brief example here.
-.. If there are multiple examples
-.. (such as one from a command-line context and another that uses the Python API)
-.. you can separate each example into a different subsection for clarity.
-
-MatchOptimisticBTask is a subtask of AstrometryTask, which is called by
-PhotoCalTask.
-
-See :lsst-task:`lsst.pipe.tasks.photoCal.PhotoCalTask`
-.. note:: Pipe task will require conversion before this link is useable.
-
 .. _lsst.meas.astrom.matchOptimisticBTask.MatchOptimisticBTask-debug:
 
 Debugging
 =========
 
-The `lsst.pipe.base.cmdLineTask.CmdLineTask` command line task interface supports a flag -d to import debug.py from your PYTHONPATH; see `lsstDebug` for more about debug.py files.
+The `lsst.pipe.base.cmdLineTask.CmdLineTask` command line task interface supports a flag -d to import debug.py from your PYTHONPATH; see :ref:`lsstDebug` for more about debug.py files.
 
 The available variables in MatchOptimisticB are
 
@@ -95,4 +79,4 @@ To investigate the meas_astrom_astrometry_Debug, put something like
 
     lsstDebug.Info = DebugInfo
 
-into your debug.py file and run this task with the --debug flag.
+into your debug.py file and run this task with the ``--debug`` flag.


### PR DESCRIPTION
lsstDebug references are now linked to the lsstDebug docs rather than indirectly, as well as some minor readability edits.

Removed extra examples which were outdated in the documents and not accurate.