### PR TITLE
Add check for match_n_finite_min >= 2

### DIFF
--- a/python/lsst/meas/astrom/matcher_probabilistic.py
+++ b/python/lsst/meas/astrom/matcher_probabilistic.py
@@ -409,6 +409,7 @@ class MatchProbabilisticConfig(pexConfig.Config):
         default=2,
         optional=True,
         doc='Minimum number of columns with a finite value to measure match likelihood',
+        check=lambda x: x >= 2,
     )
     order_ascending = pexConfig.Field(
         dtype=bool,


### PR DESCRIPTION
The two coordinate columns should always be finite anyway, but this could prevent some user errors.